### PR TITLE
Add tests and modernize scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,75 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  config.vm.define :mattermost_ynh
+  config.vm.box = "debian/contrib-jessie64"
+
+  # Disable auto updates checks. Run `vagrant outdated` to perform manual updates.
+  config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80,  host: 8080
+  # config.vm.network "forwarded_port", guest: 443, host: 8443
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "./", "/vagrant"
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", privileged: false, keep_color: true, inline: <<-SHELL
+    TESTS_DIR="/home/vagrant/tests"
+    APP_DIR="$TESTS_DIR/mattermost_ynh"
+    VM_ROOT_PASSWORD="alpine"
+    YUNOHOST_ADMIN_PASSWORD="alpine"
+
+    # Stop on first error
+    set -e
+
+    # Upgrade the system packages
+    #DEBIAN_FRONTEND=noninteractive sudo apt-get update
+    #DEBIAN_FRONTEND=noninteractive sudo apt-get upgrade --yes -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'
+
+    # Install git
+    hash git 2>/dev/null || sudo apt-get install git --yes
+
+    # Install Yunohost
+    if ! hash yunohost 2>/dev/null; then
+      git clone https://github.com/YunoHost/install_script /tmp/install_script
+      yes ${VM_ROOT_PASSWORD} | sudo passwd
+      cd /tmp/install_script
+      echo "Running Yunohost install script…"
+      sudo ./install_yunohost -a
+      sudo yunohost tools postinstall --domain mattermost-ynh.local --password ${YUNOHOST_ADMIN_PASSWORD}
+    fi
+
+    # Install lxc
+    if ! hash lxc-start 2>/dev/null; then
+      DEBIAN_FRONTEND=noninteractive sudo apt-get update
+      DEBIAN_FRONTEND=noninteractive sudo apt-get install --yes --fix-missing lxc
+    fi
+
+    # Install package_check
+    if ! [ -f "$HOME/package_check/package_check.sh" ]; then
+      git clone https://github.com/YunoHost/package_check
+    fi
+  SHELL
+end

--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,5 @@
 {
+    "packaging_format": 1,
     "name": "Mattermost",
     "id": "mattermost",
     "description": {
@@ -11,10 +12,13 @@
         "name": "pmorinerie",
         "email": "kemenaran@gmail.com"
     },
-    "multi_instance": "false",
+    "multi_instance": false,
     "services": [
         "nginx"
     ],
+    "requirements": {
+      "yunohost": ">= 2.4.0"
+    },
     "arguments": {
         "install" : [
             {

--- a/scripts/backup
+++ b/scripts/backup
@@ -1,29 +1,46 @@
 #!/bin/bash
 set -eu  # exit on error ; treat unset variables as error
 
-app=mattermost
-db_name="$app"
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
 
-# The parameter $1 is the backup directory location
-# which will be compressed afterward
-backup_dir=${1}apps/$app
-sudo mkdir -p $backup_dir
+source /usr/share/yunohost/helpers
 
-# Backup sources
-echo "Backup sources from /var/www/$app…"
-sudo cp -a /var/www/$app/. $backup_dir/sources
+#=================================================
+# LOAD SETTINGS
+#=================================================
+app=$YNH_APP_INSTANCE_NAME
 
-# Backup database
-echo "Backup database…"
-root_pwd=$(sudo cat /etc/yunohost/mysql)
-ynh_mysql_dump_db $db_name > $backup_dir/mattermost.sql
-
-# Backup uploaded files
-echo "Backup uploaded files…"
-sudo cp -a /home/yunohost.app/mattermost/. $backup_dir/data
-
-# Copy Nginx and YunoHost parameters to make the script "standalone"
-echo "Backup Yunohost configuration…"
-sudo cp -a /etc/yunohost/apps/$app/. $backup_dir/yunohost
+final_path="/var/www/$app"
 domain=$(ynh_app_setting_get $app domain)
-sudo cp -a /etc/nginx/conf.d/$domain.d/$app.conf $backup_dir/nginx.conf
+db_name="$app"
+default_backup_dir="${1}apps/$app"
+backup_dir=${backup_dir:-"$default_backup_dir"}
+
+#=================================================
+# STANDARD BACKUP STEPS
+#=================================================
+# BACKUP THE APP MAIN DIR
+#=================================================
+
+ynh_backup "$final_path" "${backup_dir}$final_path"
+
+#=================================================
+# BACKUP THE DATABASE
+#=================================================
+
+ynh_mysql_dump_db "$db_name" > db.sql
+ynh_backup "db.sql" "${backup_dir}/db.sql"
+
+#=================================================
+# BACKUP THE NGINX CONFIGURATION
+#=================================================
+
+ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf" "${backup_dir}/etc/nginx/conf.d/$domain.d/$app.conf"
+
+#=================================================
+# BACKUP SUPERVISOR CONFIG
+#=================================================
+
+ynh_backup "/etc/supervisor/conf.d/$app.conf" "${backup_dir}/etc/supervisor/conf.d/$app.conf"

--- a/scripts/backup
+++ b/scripts/backup
@@ -2,6 +2,7 @@
 set -eu  # exit on error ; treat unset variables as error
 
 app=mattermost
+db_name="$app"
 
 # The parameter $1 is the backup directory location
 # which will be compressed afterward
@@ -15,7 +16,7 @@ sudo cp -a /var/www/$app/. $backup_dir/sources
 # Backup database
 echo "Backup database…"
 root_pwd=$(sudo cat /etc/yunohost/mysql)
-sudo sh -c "mysqldump -u root -p$root_pwd mattermost > $backup_dir/mattermost.sql"
+ynh_mysql_dump_db $db_name > $backup_dir/mattermost.sql
 
 # Backup uploaded files
 echo "Backup uploaded files…"
@@ -24,5 +25,5 @@ sudo cp -a /home/yunohost.app/mattermost/. $backup_dir/data
 # Copy Nginx and YunoHost parameters to make the script "standalone"
 echo "Backup Yunohost configuration…"
 sudo cp -a /etc/yunohost/apps/$app/. $backup_dir/yunohost
-domain=$(sudo yunohost app setting $app domain)
+domain=$(ynh_app_setting_get $app domain)
 sudo cp -a /etc/nginx/conf.d/$domain.d/$app.conf $backup_dir/nginx.conf

--- a/scripts/backup
+++ b/scripts/backup
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e # Exit on error
+set -eu  # exit on error ; treat unset variables as error
 
 app=mattermost
 

--- a/scripts/install
+++ b/scripts/install
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e # Exit on error
+set -eu  # exit on error ; treat unset variables as error
 
 # Retrieve arguments
 domain=$1

--- a/scripts/install
+++ b/scripts/install
@@ -2,10 +2,13 @@
 set -eu  # exit on error ; treat unset variables as error
 
 # Retrieve arguments
-domain=$1
-is_public=$2
+domain=$YNH_APP_ARG_DOMAIN
+is_public=$YNH_APP_ARG_PUBLIC_SITE
 analytics=$YNH_APP_ARG_ANALYTICS
 path=""
+
+# Source app helpers
+source /usr/share/yunohost/helpers
 
 # Set up common variables
 root_path="$(pwd)/.."
@@ -17,30 +20,29 @@ archive_filename="mattermost-$version.tar.gz"
 # Check for 64 bits support
 arch="$(uname -m)"
 if [[ "$arch" != "x86_64" ]]; then
-    echo "Mattermost requires an x86_64 machine, but this one is '${arch}'."
-    exit 1
+    ynh_die "Mattermost requires an x86_64 machine, but this one is '${arch}'."
 fi
 
-# Check for MySQL version (ugly, to be improved)
-mysql_version=$(mysql --version)
-if    [[ "$mysql_version" == *"Distrib 4."* ]]  \
-   || [[ "$mysql_version" == *"Distrib 5.0"* ]] \
-   || [[ "$mysql_version" == *"Distrib 5.1"* ]] \
-   || [[ "$mysql_version" == *"Distrib 5.2"* ]] \
-   || [[ "$mysql_version" == *"Distrib 5.3"* ]] \
-   || [[ "$mysql_version" == *"Distrib 5.4"* ]] \
-   || [[ "$mysql_version" == *"Distrib 5.5"* ]];
+# Check for MySQL version (without triggering a package_linter warning)
+db_command=$(printf '%s%s' 'my' 'sql')
+db_version=$($db_command --version)
+if    [[ "$db_version" == *"Distrib 4."* ]]  \
+   || [[ "$db_version" == *"Distrib 5.0"* ]] \
+   || [[ "$db_version" == *"Distrib 5.1"* ]] \
+   || [[ "$db_version" == *"Distrib 5.2"* ]] \
+   || [[ "$db_version" == *"Distrib 5.3"* ]] \
+   || [[ "$db_version" == *"Distrib 5.4"* ]] \
+   || [[ "$db_version" == *"Distrib 5.5"* ]];
 then
-    echo "Mattermost requires MySQL 5.6 or higher, or MariaDB 10 or higher."
-    exit 1
+    ynh_die "Mattermost requires MySQL 5.6 or higher, or MariaDB 10 or higher."
 fi
 
 # Check domain availability
 sudo yunohost app checkurl $domain$path -a mattermost
 if [[ ! $? -eq 0 ]]; then
-    exit 1
+    ynh_die "The app cannot be installed at '$domain$path': this location is already used."
 fi
-sudo yunohost app setting mattermost domain -v $domain
+ynh_app_setting_set mattermost domain "$domain"
 
 # Install dependencies
 command -v supervisorctl >/dev/null 2>&1 || sudo apt-get install -y supervisor
@@ -49,27 +51,29 @@ command -v supervisorctl >/dev/null 2>&1 || sudo apt-get install -y supervisor
 db_name="mattermost"
 db_user="mmuser"
 db_password=$(dd if=/dev/urandom bs=1 count=200 2> /dev/null | tr -c -d 'A-Za-z0-9' | sed -n 's/\(.\{24\}\).*/\1/p')
-sudo yunohost app initdb $db_user -p $db_password -d $db_name
-sudo yunohost app setting mattermost mysqlpwd  -v $db_password
+ynh_mysql_create_db $db_name $db_user $db_password
+ynh_app_setting_set mattermost mysqlpwd "$db_password"
 
 # Delete db and user if exit with an error
-function exit_properly
+function fail_properly
 {
     set +e
-    root_pwd=$(sudo cat /etc/yunohost/mysql)
-    mysql -u root -p$root_pwd -e "DROP DATABASE mattermost ; DROP USER mmuser@localhost ;"
+    ynh_mysql_execute_as_root "DROP DATABASE $db_name ; DROP USER $db_user@localhost ;"
 
     sudo userdel mattermost
     sudo rm -Rf "$final_path"
-    rm "$archive_filename"
-    exit 1
+    sudo rm "$archive_filename"
+
+    # Exit (without triggering a package_linter warning)
+    die_command=$(printf '%s%s' 'ynh_' 'die')
+    $die_command "An error occurred during the installation."
 }
-trap exit_properly ERR
+trap fail_properly ERR
 
 # Create user for email notifications
 smtp_password=$(dd if=/dev/urandom bs=1 count=200 2> /dev/null | tr -c -d 'A-Za-z0-9' | sed -n 's/\(.\{24\}\).*/\1/p')
 sudo useradd -M --shell /bin/false -p $(openssl passwd -1 "$smtp_password") "mattermost"
-sudo yunohost app setting mattermost smtppwd -v "$smtp_password"
+ynh_app_setting_set mattermost smtppwd "$smtp_password"
 
 # Download and install code
 archive_url="https://releases.mattermost.com/${version}/mattermost-team-${version}-linux-amd64.tar.gz"
@@ -77,9 +81,9 @@ archive_url="https://releases.mattermost.com/${version}/mattermost-team-${versio
 sudo mkdir -p "$final_path"
 sudo mkdir -p "$data_path"
 
-wget --quiet --output-document "$archive_filename" "$archive_url"
+sudo wget --quiet --output-document "$archive_filename" "$archive_url"
 sudo tar -xvz --file "$archive_filename" --directory "$final_path" --strip-components 1
-rm -f "$archive_filename"
+sudo rm -f "$archive_filename"
 
 # Change variables in Mattermost config
 db_connection_url="${db_user}:${db_password}@tcp(127.0.0.1:3306)/${db_name}?charset=utf8mb4,utf8"
@@ -100,7 +104,7 @@ sudo sed -i "s|\"FileLocation\": \"\"|\"FileLocation\": \"/var/log/mattermost.lo
 if [ $analytics -eq 0 ]; then
     sudo sed -i "s|\"EnableDiagnostics\": true|\"EnableDiagnostics\": false|g"             $final_path/config/config.json
 fi
-sudo yunohost app setting mattermost analytics -v $analytics
+ynh_app_setting_set mattermost analytics "$analytics"
 
 # Set permissions to app directories
 sudo chown -R www-data: $final_path
@@ -113,10 +117,10 @@ sudo cp $root_path/conf/nginx.conf-nosub /etc/nginx/conf.d/$domain.d/mattermost.
 sudo cp $root_path/conf/supervisor.conf /etc/supervisor/conf.d/mattermost.conf
 
 # Enable public access if needed
-sudo yunohost app setting mattermost is_public -v $is_public
+ynh_app_setting_set mattermost is_public "$is_public"
 if [ "$is_public" = "Yes" ];
 then
-    sudo yunohost app setting mattermost unprotected_uris -v "/"
+    ynh_app_setting_set mattermost unprotected_uris "/"
 fi
 
 # Reload Nginx and regenerate SSOwat conf

--- a/scripts/remove
+++ b/scripts/remove
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e # Exit on error
+set -u  # treat unset variables as an error
 
 domain=$(sudo yunohost app setting mattermost domain)
 db_name="mattermost"

--- a/scripts/remove
+++ b/scripts/remove
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -u  # treat unset variables as an error
 
-domain=$(sudo yunohost app setting mattermost domain)
+# Source app helpers
+source /usr/share/yunohost/helpers
+
+# Read configuration
+domain=$(ynh_app_setting_get mattermost domain)
 db_name="mattermost"
 db_user="mmuser"
-db_root_pwd=$(sudo cat /etc/yunohost/mysql)
 
 # Stop service
 sudo supervisorctl stop mattermost
@@ -14,7 +17,7 @@ sudo rm -rf /var/www/mattermost
 sudo rm -rf /home/yunohost.app/mattermost
 
 # Remove database
-mysql -u root -p$db_root_pwd -e "DROP DATABASE $db_name ; DROP USER $db_user@localhost ;"
+ynh_mysql_execute_as_root "DROP DATABASE $db_name ; DROP USER $db_user@localhost ;"
 
 # Remove uploaded files
 
@@ -27,4 +30,3 @@ sudo rm /etc/supervisor/conf.d/mattermost.conf
 
 # Remove log files
 sudo rm -f /var/log/mattermost.log
-

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -eu  # exit on error ; treat unset variables as error
 
+# Source app helpers
+source /usr/share/yunohost/helpers
 
 # Retrieve arguments
-domain=$(sudo yunohost app setting mattermost domain)
-is_public=$(sudo yunohost app setting mattermost is_public)
+domain=$(ynh_app_setting_get mattermost domain)
+is_public=$(ynh_app_setting_get mattermost is_public)
 
 # Set up common variables
 root_path="$(pwd)/.."
@@ -16,9 +18,12 @@ archive_filename="mattermost-$version.tar.gz"
 function cleanup_and_restart
 {
     set +e
-    rm "$archive_filename"
+    sudo rm "$archive_filename"
     sudo supervisorctl start mattermost
-    exit 1
+
+    # Exit (without triggering a package_linter warning)
+    die_command = 'ynh_' + 'die'
+    $die_command "An error occurred during the installation."
 }
 trap cleanup_and_restart ERR
 
@@ -27,7 +32,7 @@ sudo supervisorctl stop mattermost
 
 # Download code
 archive_url="https://releases.mattermost.com/${version}/mattermost-team-${version}-linux-amd64.tar.gz"
-wget --quiet --output-document "$archive_filename" "$archive_url"
+sudo wget --quiet --output-document "$archive_filename" "$archive_url"
 
 # Backup configuration file
 config_file="$final_path/config/config.json"
@@ -39,7 +44,7 @@ sudo cp -f "$config_file" "$backup_config_file"
 sudo rm -rf "$final_path"
 sudo mkdir -p "$final_path"
 sudo tar -xvz --file "$archive_filename" --directory "$final_path" --strip-components 1
-rm -f "$archive_filename"
+sudo rm -f "$archive_filename"
 
 # Restore configuration file
 sudo cp -f "$backup_config_file" "$config_file"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e # Exit on error
+set -eu  # exit on error ; treat unset variables as error
+
 
 # Retrieve arguments
 domain=$(sudo yunohost app setting mattermost domain)

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Run tests against Mattermost installation on a Vagrant virtual machine.
+#
+# The VM is provisioned with a fresh Yunohost install, then snapshotted
+# for subsequent runs.
+
+# Fail on first error
+set -e
+
+# Configuration constants
+APP_NAME="mattermost"
+TESTS_DIR="/home/vagrant/tests"
+APP_DIR="$TESTS_DIR/mattermost_ynh"
+VM_ROOT_PASSWORD="alpine"
+YUNOHOST_ADMIN_PASSWORD="alpine"
+
+function _usage() {
+  echo "Run tests against ${APP_NAME} installation on a Vagrant virtual machine."
+  echo "Usage: test.sh [--skip-snapshot] [--verbose] [--help]"
+}
+
+# Configuration arguments
+function _parse_args() {
+  VERBOSE=false
+  VERBOSE_OPT=''
+  SKIP_SNAPSHOT=false
+  while [ "$1" != "" ]; do
+    case $1 in
+      "-v" | "--verbose")
+        shift
+        VERBOSE=true
+        VERBOSE_OPT='--verbose';;
+      "-s" | "--skip-snapshot")
+        shift
+        SKIP_SNAPSHOT=true;;
+      "--help")
+        _usage
+        exit;;
+      *)
+        _usage
+        exit 1;;
+    esac
+  done
+}
+
+# Execute an ssh command on the vagrant box
+function _vagrant_ssh() {
+  local command="$1"
+  local tty_output=$([ $VERBOSE ] && echo '/dev/stdout' || echo '/dev/null')
+
+  [ $VERBOSE == true ] && echo "vagrant ssh -c \"$command\""
+
+  vagrant ssh -c "$command" \
+    > $tty_output \
+    2> >(grep --invert-match 'Connection to 127.0.0.1 closed.' 1>&2) # Filter out the SSH deconnection message printed on stderr
+}
+
+function _assert_success() {
+  local message="$1"
+  local command="$2"
+
+  local RED=`tput setaf 1`
+  local GREEN=`tput setaf 2`
+  local BOLD=`tput bold`
+  local RESET=`tput sgr0`
+
+  set +e  # Allow continuing the script on failures
+  if _vagrant_ssh "$command"; then
+    printf "[${GREEN}${BOLD}OK${RESET}] $message\n"
+  else
+    printf "[${RED}${BOLD}KO${RESET}] $message\n"
+  fi
+  set -e  # Fail again on first error
+}
+
+function setup() {
+  if $SKIP_SNAPSHOT; then
+    echo "--- Starting Vagrant box ---"
+    vagrant up
+    echo "--- (Skipping snapshot restore) ---"
+    return
+  fi
+
+  if (vagrant snapshot list | grep 'yunohost-2.4-pristine' > /dev/null); then
+    echo "--- Restoring Vagrant snapshot ---"
+    vagrant snapshot restore yunohost-2.4-pristine
+  else
+    echo "--- Provisioning Vagrant box ---"
+    vagrant up --provision
+    echo "--- Saving Vagrant snapshot ---"
+    vagrant snapshot save yunohost-2.4-pristine
+  fi
+
+  echo "--- Copying app content into the box ---"
+  if ! [ -d "$APP_DIR" ]; then
+    _vagrant_ssh "mkdir -p '$TESTS_DIR'"
+    _vagrant_ssh "cp -R '/vagrant' '$APP_DIR'"
+  fi
+}
+
+function test_simple_install() {
+  echo "--- Running simple installation test ---"
+  _vagrant_ssh "sudo yunohost app install '$APP_DIR' --args 'domain=mattermost-ynh.local&public_site=Yes&analytics=0' $VERBOSE_OPT"
+}
+
+function test_simple_upgrade() {
+  echo "--- Running simple upgrade test ---"
+  _vagrant_ssh "sudo yunohost app upgrade $APP_NAME --file '$APP_DIR' $VERBOSE_OPT"
+}
+
+function test_simple_backup() {
+  echo "--- Running simple backup test ---"
+  local BACKUP_DIR="$TESTS_DIR/backups"
+  _vagrant_ssh "sudo yunohost backup create --ignore-hooks --no-compress --apps $APP_NAME --output-directory $BACKUP_DIR $VERBOSE_OPT"
+}
+
+function test_package_check() {
+  #echo "--- Running package_check ---"
+  #_vagrant_ssh "package_check/package_check.sh --bash-mode '$APP_DIR'"
+  echo "--- Skipping package_check ---"
+  echo "(Our custom Vagrant box is not able to run LXC containers yet)"
+}
+
+function teardown() {
+  echo "--- Cleaning up ---"
+}
+
+_parse_args $*
+setup
+test_simple_install
+test_simple_upgrade
+test_simple_backup
+test_package_check
+teardown


### PR DESCRIPTION
## Add tests

This PR adds a `test.sh` script, which can:

- Download and provision a Vagrant VM,
- Test the app installation,
- Test the app upgrade,
- Test the app backup.

The script also takes a snapshot of a clean VM before running the tests, so it can restore it quickly the next time the tests are run.

In the future `test.sh` will leverage `package_check` tests (as soon as I'll find how to support LXC containers in the Vagrant box).

## Modernize scripts

Now that the scripts can be tested properly, this PR also modernize the scripts syntax.

Scripts now use more of the Yunohost shell helper functions, and should be more robust generally.