### PR TITLE
scripts: don’t warn when supervisor config file doesn’t exist

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -26,7 +26,7 @@ sudo userdel mattermost
 
 # Remove configuration files
 sudo rm -f /etc/nginx/conf.d/$domain.d/mattermost.conf
-sudo rm /etc/supervisor/conf.d/mattermost.conf
+sudo rm -f /etc/supervisor/conf.d/mattermost.conf
 
 # Remove log files
 sudo rm -f /var/log/mattermost.log


### PR DESCRIPTION
Fixes a warning when executing the `remove` script and the supervisor config has not been installed yet (like when a backup fails).