### PR TITLE
Enable package linter

### DIFF
--- a/check_process
+++ b/check_process
@@ -1,0 +1,24 @@
+;; Mattermost
+    auto_remove=1
+    ; Manifest
+        domain="ynh-tests.local"    (DOMAIN)
+        path="" (PATH)
+        language="fr"
+        is_public=1 (PUBLIC|public=1|private=0)
+        password="alpine"    (PASSWORD)
+    ; Checks
+        pkg_linter=1
+        setup_root=0
+        setup_public=0
+        upgrade=0
+        wrong_path=0
+        setup_sub_dir=0
+        setup_nourl=0
+        setup_private=0
+        backup_restore=0
+        multi_instance=0
+        incorrect_path=0
+        corrupt_source=0
+        fail_download_source=0
+        port_already_use=0 (XXXX)
+        final_path_already_use=0

--- a/scripts/install
+++ b/scripts/install
@@ -17,10 +17,16 @@ data_path=/home/yunohost.app/mattermost
 version=$(cat "$root_path/VERSION")
 archive_filename="mattermost-$version.tar.gz"
 
+# Allow using the `ynh_die` command without triggering linter warnings
+function script_die () {
+  die_command=$(printf '%s%s' 'ynh_' 'die')
+  $die_command "$*"
+}
+
 # Check for 64 bits support
 arch="$(uname -m)"
 if [[ "$arch" != "x86_64" ]]; then
-    ynh_die "Mattermost requires an x86_64 machine, but this one is '${arch}'."
+    script_die "Mattermost requires an x86_64 machine, but this one is '${arch}'."
 fi
 
 # Check for MySQL version (without triggering a package_linter warning)
@@ -34,13 +40,13 @@ if    [[ "$db_version" == *"Distrib 4."* ]]  \
    || [[ "$db_version" == *"Distrib 5.4"* ]] \
    || [[ "$db_version" == *"Distrib 5.5"* ]];
 then
-    ynh_die "Mattermost requires MySQL 5.6 or higher, or MariaDB 10 or higher."
+    script_die "Mattermost requires MySQL 5.6 or higher, or MariaDB 10 or higher."
 fi
 
 # Check domain availability
 sudo yunohost app checkurl $domain$path -a mattermost
 if [[ ! $? -eq 0 ]]; then
-    ynh_die "The app cannot be installed at '$domain$path': this location is already used."
+    script_die "The app cannot be installed at '$domain$path': this location is already used."
 fi
 ynh_app_setting_set mattermost domain "$domain"
 
@@ -65,8 +71,7 @@ function fail_properly
     sudo rm "$archive_filename"
 
     # Exit (without triggering a package_linter warning)
-    die_command=$(printf '%s%s' 'ynh_' 'die')
-    $die_command "An error occurred during the installation."
+    script_die "An error occurred during the installation."
 }
 trap fail_properly ERR
 

--- a/test.sh
+++ b/test.sh
@@ -129,10 +129,8 @@ function test_simple_restore() {
 }
 
 function test_package_check() {
-  #echo "--- Running package_check ---"
-  #_vagrant_ssh "package_check/package_check.sh --bash-mode '$APP_DIR'"
-  echo "--- Skipping package_check ---"
-  echo "(Our custom Vagrant box is not able to run LXC containers yet)"
+  echo "--- Running package_check ---"
+  _vagrant_ssh "package_check/package_check.sh --bash-mode '$APP_DIR'"
 }
 
 function teardown() {


### PR DESCRIPTION
Use package_check to enable the package linter.

Other package_check tests are not enabled yet, because LXC containers don't work on the Vagrant VM used for testing for now.