### PR TITLE
scripts: use `ynh_abort_if_errors` helper

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -1,11 +1,17 @@
 #!/bin/bash
-set -eu  # exit on error ; treat unset variables as error
 
 #=================================================
 # IMPORT GENERIC HELPERS
 #=================================================
 
 source /usr/share/yunohost/helpers
+
+#=================================================
+# MANAGE SCRIPT FAILURE
+#=================================================
+
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
 
 #=================================================
 # LOAD SETTINGS

--- a/scripts/install
+++ b/scripts/install
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -eu  # exit on error ; treat unset variables as error
 
 # Retrieve arguments
 domain=$YNH_APP_ARG_DOMAIN
@@ -9,6 +8,9 @@ path=""
 
 # Source app helpers
 source /usr/share/yunohost/helpers
+
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
 
 # Set up common variables
 root_path="$(pwd)/.."

--- a/scripts/restore
+++ b/scripts/restore
@@ -1,11 +1,17 @@
 #!/bin/bash
-set -eu  # exit on error ; treat unset variables as error
 
 #=================================================
 # IMPORT GENERIC HELPERS
 #=================================================
 
 source /usr/share/yunohost/helpers
+
+#=================================================
+# MANAGE SCRIPT FAILURE
+#=================================================
+
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
 
 #=================================================
 # LOAD SETTINGS

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,8 +1,10 @@
 #!/bin/bash
-set -eu  # exit on error ; treat unset variables as error
 
 # Source app helpers
 source /usr/share/yunohost/helpers
+
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
 
 # Retrieve arguments
 domain=$(ynh_app_setting_get mattermost domain)


### PR DESCRIPTION
Fix a package_linter warning:

> ✘ [YEP-2.4] ynh_abort_if_errors is missing. For details,look at https://dev.yunohost.org/issues/419 