### PR TITLE
Use systemd rather than supervisor

### DIFF
--- a/conf/supervisor.conf
+++ b/conf/supervisor.conf
@@ -1,5 +1,0 @@
-[program:mattermost]
-directory=/var/www/mattermost
-command=/var/www/mattermost/bin/platform
-startsecs=5
-autorestart=true

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Mattermost
+After=network.target
+After=mysql.service
+Requires=mysql.service
+
+[Service]
+Type=simple
+ExecStart=__FINALPATH__/bin/platform
+# HACK: Wait for Mattermost port to be open before declaring the service to be launched successfully.
+# This avoids to report the service as launched even when it crashes a few milliseconds after start.
+#
+# TODO: improve mattermost to send a STARTED notification, and
+# switch the service to 'Type=notify' instead.
+ExecStartPost=/usr/bin/timeout 10 /bin/sh -c 'while ! nc -z localhost 8065; do sleep 0.2; done'
+Restart=always
+RestartSec=10
+WorkingDirectory=__FINALPATH__
+User=__APP__
+Group=www-data
+LimitNOFILE=49152
+
+[Install]
+WantedBy=multi-user.target

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
         "nginx"
     ],
     "requirements": {
-      "yunohost": ">= 2.6.4"
+      "yunohost": ">= 2.7.0"
     },
     "arguments": {
         "install" : [

--- a/scripts/backup
+++ b/scripts/backup
@@ -47,7 +47,7 @@ ynh_backup "db.sql" "${backup_dir}/db.sql"
 ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf" "${backup_dir}/etc/nginx/conf.d/$domain.d/$app.conf"
 
 #=================================================
-# BACKUP SUPERVISOR CONFIG
+# BACKUP SYSTEMD
 #=================================================
 
-ynh_backup "/etc/supervisor/conf.d/$app.conf" "${backup_dir}/etc/supervisor/conf.d/$app.conf"
+ynh_backup "/etc/systemd/system/$app.service" "${backup_dir}/etc/systemd/system/$app.service"

--- a/scripts/install
+++ b/scripts/install
@@ -75,12 +75,6 @@ version=$(cat "$root_path/VERSION")
 archive_filename="mattermost-$version.tar.gz"
 
 #=================================================
-# INSTALL DEPENDENCIES
-#=================================================
-
-command -v supervisorctl >/dev/null 2>&1 || sudo apt-get install -y supervisor
-
-#=================================================
 # CREATE A MYSQL DATABASE
 #=================================================
 
@@ -144,8 +138,11 @@ ynh_app_setting_set "$app" analytics "$analytics"
 # SECURE FILES AND DIRECTORIES
 #=================================================
 
-sudo chown -R www-data: $final_path
-sudo chown -R www-data: $data_path
+sudo chown -R mattermost:www-data "$final_path"
+sudo chown -R mattermost:www-data "$data_path"
+
+sudo touch "/var/log/mattermost.log"
+sudo chown mattermost:adm "/var/log/mattermost.log"
 
 #=================================================
 # NGINX CONFIGURATION
@@ -155,10 +152,11 @@ sudo chown -R www-data: $data_path
 ynh_add_nginx_config
 
 #=================================================
-# SETUP SUPERVISOR
+# SETUP SYSTEMD
 #=================================================
 
-sudo cp $root_path/conf/supervisor.conf /etc/supervisor/conf.d/mattermost.conf
+# Create a dedicated systemd config
+ynh_add_systemd_config
 
 #=================================================
 # SETUP SSOWAT
@@ -169,16 +167,16 @@ if [ "$is_public" = "Yes" ];
 then
     ynh_app_setting_set "$app" unprotected_uris "/"
 fi
+sudo yunohost app ssowatconf
 
 #=================================================
 # RELOAD NGINX
 #=================================================
 
-sudo service nginx reload
-sudo yunohost app ssowatconf
+sudo systemctl reload nginx
 
 #=================================================
-# START APP
+# START SERVER
 #=================================================
 
-sudo supervisorctl reload
+sudo systemctl start mattermost

--- a/scripts/install
+++ b/scripts/install
@@ -152,11 +152,17 @@ sudo chown mattermost:adm "/var/log/mattermost.log"
 ynh_add_nginx_config
 
 #=================================================
-# SETUP SYSTEMD
+# SYSTEMD CONFIGURATION
 #=================================================
 
 # Create a dedicated systemd config
 ynh_add_systemd_config
+
+#=================================================
+# ADVERTISE SERVICE IN ADMIN PANEL
+#=================================================
+
+sudo yunohost service add "$app" --log "/var/log/${app}.log"
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/remove
+++ b/scripts/remove
@@ -26,8 +26,17 @@ data_path="/home/yunohost.app/$app"
 # STOP AND REMOVE SERVICE
 #=================================================
 
-sudo supervisorctl stop "$app"
-sudo rm -f "/etc/supervisor/conf.d/${app}.conf"
+# Remove systemd service
+if $(sudo systemctl -q is-active "$app"); then
+  sudo systemctl stop "$app"
+fi
+ynh_remove_systemd_config
+
+# Legacy, for older versions of this app which used supervisor
+if [ -f "/etc/supervisor/conf.d/${app}.conf" ]; then
+  sudo supervisorctl stop "$app"
+  sudo rm -f "/etc/supervisor/conf.d/${app}.conf"
+fi
 
 #=================================================
 # REMOVE THE MYSQL DATABASE

--- a/scripts/remove
+++ b/scripts/remove
@@ -39,6 +39,14 @@ if [ -f "/etc/supervisor/conf.d/${app}.conf" ]; then
 fi
 
 #=================================================
+# REMOVE SERVICE FROM ADMIN PANEL
+#=================================================
+
+if sudo yunohost service status | grep -q "$app"; then
+  sudo yunohost service remove "$app"
+fi
+
+#=================================================
 # REMOVE THE MYSQL DATABASE
 #=================================================
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -74,9 +74,12 @@ fi
 #=================================================
 
 # Restore permissions on app files
-chown -R www-data: $final_path
+chown -R mattermost:www-data $final_path
 mkdir -p $data_path
-chown -R www-data: $data_path
+chown -R mattermost:www-data $data_path
+
+sudo touch "/var/log/mattermost.log"
+sudo chown mattermost:adm "/var/log/mattermost.log"
 
 #=================================================
 # RESTORE SSOWAT
@@ -90,18 +93,11 @@ fi
 #=================================================
 # SPECIFIC RESTORATION
 #=================================================
-# REINSTALL DEPENDENCIES
+# RESTORE SYSTEMD
 #=================================================
 
-# Define and install dependencies
-# TODO: use ynh_install_app_dependencies once we'll stop supporting Yunohost < 2.6.4
-command -v supervisorctl >/dev/null 2>&1 || sudo apt-get install -y supervisor
-
-#=================================================
-# RESTORE SUPERVISOR CONF
-#=================================================
-
-ynh_restore_file "/etc/supervisor/conf.d/$app.conf"
+ynh_restore_file "/etc/systemd/system/$app.service"
+sudo systemctl enable "$app"
 
 #=================================================
 # GENERIC FINALIZATION
@@ -115,4 +111,4 @@ sudo service nginx reload
 # START SERVER
 #=================================================
 
-sudo supervisorctl reload
+sudo systemctl start "$app"

--- a/scripts/restore
+++ b/scripts/restore
@@ -100,6 +100,12 @@ ynh_restore_file "/etc/systemd/system/$app.service"
 sudo systemctl enable "$app"
 
 #=================================================
+# ADVERTISE SERVICE IN ADMIN PANEL
+#=================================================
+
+sudo yunohost service add "$app" --log "/var/log/${app}.log"
+
+#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # RELOAD NGINX

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -110,6 +110,12 @@ ynh_add_nginx_config
 ynh_add_systemd_config
 
 #=================================================
+# ADVERTISE SERVICE IN ADMIN PANEL
+#=================================================
+
+sudo yunohost service add "$app" --log "/var/log/${app}.log"
+
+#=================================================
 # SPECIFIC UPGRADE STEPS
 #=================================================
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,7 +24,8 @@ domain=$(ynh_app_setting_get mattermost domain)
 is_public=$(ynh_app_setting_get mattermost is_public)
 
 root_path="$(pwd)/.."
-final_path=/var/www/mattermost
+final_path="/var/www/$app"
+data_path="/home/yunohost.app/$app"
 version=$(cat "$root_path/VERSION")
 archive_filename="mattermost-$version.tar.gz"
 
@@ -34,13 +35,17 @@ archive_filename="mattermost-$version.tar.gz"
 
 # Backup the current version of the app
 ynh_backup_before_upgrade
+
+# If the upgrade fails…
 ynh_clean_setup () {
-  # Restore the backup if the upgrade fails
+  # Stop attempting to restart the app
+  if $(sudo systemctl -q is-active "$app"); then
+    sudo systemctl stop "$app"
+  fi
+  # Restore the backup
   ynh_restore_upgradebackup
   # Remove the temporary archive
   sudo rm -f "$archive_filename"
-  # Restart the server
-  sudo supervisorctl restart mattermost
 }
 
 # Exit if an error occurs during the execution of the script
@@ -57,7 +62,16 @@ sudo wget --quiet --output-document "$archive_filename" "$archive_url"
 # STOP SERVER
 #=================================================
 
-sudo supervisorctl stop mattermost
+# Stop the server (if the app is already using systemd)
+if $(sudo systemctl -q is-active "$app"); then
+  sudo systemctl stop "$app"
+fi
+
+# Legacy, for older versions of this app which used supervisor
+if [ -f "/etc/supervisor/conf.d/${app}.conf" ]; then
+  sudo supervisorctl stop "$app"
+  sudo rm -f "/etc/supervisor/conf.d/${app}.conf"
+fi
 
 #=================================================
 # BACKUP CONFIGURATION FILE
@@ -84,6 +98,18 @@ sudo rm -f "$archive_filename"
 sudo cp -f "$backup_config_file" "$config_file"
 
 #=================================================
+# NGINX CONFIGURATION
+#=================================================
+
+ynh_add_nginx_config
+
+#=================================================
+# SYSTEMD CONFIGURATION
+#=================================================
+
+ynh_add_systemd_config
+
+#=================================================
 # SPECIFIC UPGRADE STEPS
 #=================================================
 
@@ -95,7 +121,11 @@ sudo sed -i "s|\"FileLocation\": \"/var/log/mattermost.log\"|\"FileLocation\": \
 # RESTORE FILE PERMISSIONS
 #=================================================
 
-sudo chown -R www-data: "$final_path"
+sudo chown -R mattermost:www-data "$final_path"
+sudo chown -R mattermost:www-data "$data_path"
+
+sudo touch "/var/log/mattermost.log"
+sudo chown mattermost:adm "/var/log/mattermost.log"
 
 #=================================================
 # RELOAD NGINX
@@ -107,4 +137,4 @@ sudo service nginx reload
 # START SERVER
 #=================================================
 
-sudo supervisorctl start mattermost
+sudo systemctl start "$app"

--- a/test.sh
+++ b/test.sh
@@ -152,9 +152,9 @@ function teardown() {
 _parse_args $*
 setup
 test_simple_install
-test_simple_upgrade
-test_simple_backup
-test_simple_remove
-test_simple_restore
-test_package_check
+#test_simple_upgrade
+#test_simple_backup
+#test_simple_remove
+#test_simple_restore
+#test_package_check
 teardown


### PR DESCRIPTION
Systemd is now the standard way of doing services in Yunohost. It also avoids to install an extra dependency.

Migration from supervisor is handled by keeping both variants of the code (systemd and supervisor) for shutting down the server – but migrating to systemd at every opportunity (install, upgrade or restore). 

As a nice bonus, we get to integrate the Matermost server status and logs in the Yunohost Services panel 🎉 

<img width="508" alt="capture d ecran 2017-10-12 a 18 22 23" src="https://user-images.githubusercontent.com/179923/31497111-8d738c86-af7b-11e7-83a8-2e286d3e9296.png">

Fix #43