### PR TITLE
scripts: move logs to a subdirectory of /var/log

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -71,6 +71,7 @@ ynh_app_setting_set "$app" domain "$domain"
 root_path="$(pwd)/.."
 final_path="/var/www/$app"
 data_path="/home/yunohost.app/$app"
+logs_path="/var/log/$app"
 version=$(cat "$root_path/VERSION")
 archive_filename="mattermost-$version.tar.gz"
 
@@ -100,6 +101,7 @@ archive_url="https://releases.mattermost.com/${version}/mattermost-team-${versio
 
 sudo mkdir -p "$final_path"
 sudo mkdir -p "$data_path"
+sudo mkdir -p "$logs_path"
 
 sudo wget --quiet --output-document "$archive_filename" "$archive_url"
 sudo tar -xvz --file "$archive_filename" --directory "$final_path" --strip-components 1
@@ -127,7 +129,7 @@ sudo sed -i "s|\"SMTPPort\": \"\"|\"SMTPPort\": \"25\"|g"                       
 # Disable Mattermost debug console by default
 sudo sed -i "s|\"EnableConsole\": true|\"EnableConsole\": false|g"                     $final_path/config/config.json
 # Configure log file location
-sudo sed -i "s|\"FileLocation\": \"\"|\"FileLocation\": \"/var/log\"|g"                $final_path/config/config.json
+sudo sed -i "s|\"FileLocation\": \"\"|\"FileLocation\": \"$logs_path\"|g"              $final_path/config/config.json
 # Configure analytics according to user choice
 if [ $analytics -eq 0 ]; then
     sudo sed -i "s|\"EnableDiagnostics\": true|\"EnableDiagnostics\": false|g"             $final_path/config/config.json
@@ -140,9 +142,7 @@ ynh_app_setting_set "$app" analytics "$analytics"
 
 sudo chown -R mattermost:www-data "$final_path"
 sudo chown -R mattermost:www-data "$data_path"
-
-sudo touch "/var/log/mattermost.log"
-sudo chown mattermost:adm "/var/log/mattermost.log"
+sudo chown -R mattermost:adm      "$logs_path"
 
 #=================================================
 # NGINX CONFIGURATION
@@ -162,7 +162,7 @@ ynh_add_systemd_config
 # ADVERTISE SERVICE IN ADMIN PANEL
 #=================================================
 
-sudo yunohost service add "$app" --log "/var/log/${app}.log"
+sudo yunohost service add "$app" --log "$logs_path/mattermost.log"
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/remove
+++ b/scripts/remove
@@ -19,6 +19,7 @@ db_name="mattermost"
 db_user="mmuser"
 final_path="/var/www/$app"
 data_path="/home/yunohost.app/$app"
+logs_path="/var/log/$app"
 
 #=================================================
 # STANDARD REMOVE
@@ -69,7 +70,7 @@ ynh_remove_nginx_config
 # REMOVE LOG FILE
 #=================================================
 
-sudo rm -f "/var/log/${app}.log"
+sudo rm -rf "$logs_path"
 
 #=================================================
 # REMOVE DEDICATED USER

--- a/scripts/restore
+++ b/scripts/restore
@@ -24,6 +24,7 @@ is_public=$(ynh_app_setting_get $app is_public)
 path_url="/"
 final_path="/var/www/$app"
 data_path="/home/yunohost.app/$app"
+logs_path="/var/log/$app"
 db_name="$app"
 db_user="mmuser"
 
@@ -74,12 +75,13 @@ fi
 #=================================================
 
 # Restore permissions on app files
-chown -R mattermost:www-data $final_path
-mkdir -p $data_path
-chown -R mattermost:www-data $data_path
+sudo chown -R mattermost:www-data "$final_path"
 
-sudo touch "/var/log/mattermost.log"
-sudo chown mattermost:adm "/var/log/mattermost.log"
+mkdir -p "$data_path"
+sudo chown -R mattermost:www-data "$data_path"
+
+mkdir -p "$logs_path"
+sudo chown -R mattermost:adm "$logs_path"
 
 #=================================================
 # RESTORE SSOWAT
@@ -103,7 +105,7 @@ sudo systemctl enable "$app"
 # ADVERTISE SERVICE IN ADMIN PANEL
 #=================================================
 
-sudo yunohost service add "$app" --log "/var/log/${app}.log"
+sudo yunohost service add "$app" --log "$logs_path/mattermost.log"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -26,6 +26,7 @@ is_public=$(ynh_app_setting_get mattermost is_public)
 root_path="$(pwd)/.."
 final_path="/var/www/$app"
 data_path="/home/yunohost.app/$app"
+logs_path="/var/log/$app"
 version=$(cat "$root_path/VERSION")
 archive_filename="mattermost-$version.tar.gz"
 
@@ -113,7 +114,7 @@ ynh_add_systemd_config
 # ADVERTISE SERVICE IN ADMIN PANEL
 #=================================================
 
-sudo yunohost service add "$app" --log "/var/log/${app}.log"
+sudo yunohost service add "$app" --log "$logs_path/mattermost.log"
 
 #=================================================
 # SPECIFIC UPGRADE STEPS
@@ -123,15 +124,21 @@ sudo yunohost service add "$app" --log "/var/log/${app}.log"
 # https://docs.mattermost.com/administration/changelog.html#release-v3-8-3
 sudo sed -i "s|\"FileLocation\": \"/var/log/mattermost.log\"|\"FileLocation\": \"/var/log\"|g" "$config_file"
 
+# Move log files to a directory (rather than directly in /var/log)
+# See https://github.com/YunoHost-Apps/mattermost_ynh/issues/61
+sudo mkdir -p "$logs_path"
+sudo sed -i "s|\"FileLocation\": \"/var/log\"|\"FileLocation\": \"$logs_path\"|g" "$config_file"
+if [ -f "/var/log/${app}.log" ]; then
+  sudo mv "/var/log/${app}.log" "$logs_path/"
+fi
+
 #=================================================
 # RESTORE FILE PERMISSIONS
 #=================================================
 
 sudo chown -R mattermost:www-data "$final_path"
 sudo chown -R mattermost:www-data "$data_path"
-
-sudo touch "/var/log/mattermost.log"
-sudo chown mattermost:adm "/var/log/mattermost.log"
+sudo chown -R mattermost:adm      "$logs_path"
 
 #=================================================
 # RELOAD NGINX


### PR DESCRIPTION
This allows to give permission to the `mattermost` user to write new files in this subdirectory, which is needed for log rotation.

Fix #61