### PR TITLE
Enable more package_check tests

### DIFF
--- a/check_process
+++ b/check_process
@@ -8,17 +8,15 @@
         password="alpine"    (PASSWORD)
     ; Checks
         pkg_linter=1
-        setup_root=0
-        setup_public=0
-        upgrade=0
-        wrong_path=0
+        setup_root=1
+        setup_private=0
+        setup_public=1
+        upgrade=1
+        backup_restore=1
+        multi_instance=0
+        port_already_use=0 (XXXX)
+        change_url=0
+        # Tests not applicable
         setup_sub_dir=0
         setup_nourl=0
-        setup_private=0
-        backup_restore=0
-        multi_instance=0
         incorrect_path=0
-        corrupt_source=0
-        fail_download_source=0
-        port_already_use=0 (XXXX)
-        final_path_already_use=0

--- a/check_process
+++ b/check_process
@@ -1,5 +1,4 @@
 ;; Mattermost
-    auto_remove=1
     ; Manifest
         domain="ynh-tests.local"    (DOMAIN)
         path="" (PATH)
@@ -20,3 +19,14 @@
         setup_sub_dir=0
         setup_nourl=0
         incorrect_path=0
+;;; Levels
+    Level 1=auto
+    Level 2=auto
+    Level 3=auto
+    Level 4=0
+    Level 5=auto
+    Level 6=auto
+    Level 7=auto
+    Level 8=0
+    Level 9=0
+    Level 10=0

--- a/check_process
+++ b/check_process
@@ -30,3 +30,6 @@
     Level 8=0
     Level 9=0
     Level 10=0
+;;; Options
+Email=kemenaran@gmail.com
+Notification=change

--- a/test.sh
+++ b/test.sh
@@ -151,7 +151,8 @@ function teardown() {
 
 _parse_args $*
 setup
-test_package_check
+# Package_check is disabled until LXC containers work properly inside the Vagrant VM
+#test_package_check
 test_simple_install
 test_simple_upgrade
 test_simple_backup


### PR DESCRIPTION
When we added a `check_process` configuration file, the `package_check` script stopped inferring tests settings automatically, and used the ones explicitly declared.

As we only declared the linting test to be enabled, Yunohost CI now fails because no tests are enabled.

This PR enables some known successful tests, so that `package_check` can run them, and the CI can check this package as working again.