### PR TITLE
Enable package_check tests in the VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.
 
-  config.vm.define :ynh_tests
+  config.vm.define :ynhtests
   config.vm.box = "yunohost/jessie-stable"
 
   # Disable auto updates checks. Run `vagrant outdated` to perform manual updates.
@@ -44,7 +44,7 @@ Vagrant.configure("2") do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", privileged: false, keep_color: true, inline: <<-SHELL
-    DOMAIN=ynh-tests.local
+    DOMAIN=ynhtests.local
     YUNOHOST_ADMIN_PASSWORD="alpine"
 
     # Stop on first error

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,14 @@ Vagrant.configure("2") do |config|
   # using a specific IP.
   config.vm.network "private_network", ip: "192.168.33.10"
 
+  # Use the NAT hosts DNS resolver. Fixes slow network in the guest.
+  # See https://serverfault.com/questions/495914/vagrant-slow-internet-connection-in-guest
+  config.vm.provider "virtualbox" do |v|
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    v.customize ["modifyvm", :id, "--nictype1", "virtio"]
+  end
+
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third

--- a/check_process
+++ b/check_process
@@ -1,6 +1,6 @@
 ;; Mattermost
     ; Manifest
-        domain="ynh-tests.local"    (DOMAIN)
+        domain="ynhtests.local"    (DOMAIN)
         path="" (PATH)
         language="fr"
         is_public=1 (PUBLIC|public=1|private=0)

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ set -e
 # Configuration constants
 APP_NAME="mattermost"
 APP_DIR="/vagrant"
-DOMAIN="ynh-tests.local"
+DOMAIN="ynhtests.local"
 VM_ROOT_PASSWORD="alpine"
 YUNOHOST_ADMIN_PASSWORD="alpine"
 

--- a/test.sh
+++ b/test.sh
@@ -142,7 +142,7 @@ function test_simple_restore() {
 
 function test_package_check() {
   echo "--- Running package_check ---"
-  _vagrant_ssh "package_check/package_check.sh --bash-mode '$APP_DIR'"
+  _vagrant_ssh "package_check/package_check.sh --build-lxc --bash-mode '$APP_DIR'"
 }
 
 function teardown() {
@@ -151,8 +151,7 @@ function teardown() {
 
 _parse_args $*
 setup
-# Package_check is disabled until LXC containers work properly inside the Vagrant VM
-#test_package_check
+test_package_check
 test_simple_install
 test_simple_upgrade
 test_simple_backup


### PR DESCRIPTION
Enable package_check tests in the Vagrant VM.

This PR:

- Ensures that LXC containers are properly configured when provisioning the VM ;
- Fix issues with `package_check` handling of containers (upstream PR pending)

This means that eventually our custom test harness will be removed, and use simply a `vagrant up; vagrant ssh -c "./package_check.sh"` command.