### PR TITLE
Update app.src

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/4.3.2/mattermost-4.3.2-linux-amd64.tar.gz
-SOURCE_SUM=e1bdef75114de7dbabc77becb267405bbacee0b5b28a93393ab2ec04fc272335
+SOURCE_URL=https://releases.mattermost.com/4.4.1/mattermost-4.4.1-linux-amd64.tar.gz
+SOURCE_SUM=ccbae71d9e96d85d23195dfdd86de623c2e17a10b2ee2d7623ef8fe46e565190
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-4.3.2-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-4.4.1-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost 4.4.1 is officially out!

Here's a quick PR to update to this version.  

You can [find download links with hash numbers here](https://pre-release.mattermost.com/core/pl/ph9peatubtne7pszys4utsyo3c).  Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html#release-v4-4-1).

If you do update, please consider tweeting about it, which we can then re-tweet for greater reach.

Thanks!