### PR TITLE
Propose updating to Mattermost 4.4.3

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/4.4.2/mattermost-4.4.2-linux-amd64.tar.gz
-SOURCE_SUM=ba1648e5806239ce9071f5730eb712a6d0d9077fd9ecad37e85baeb08c1fa170
+SOURCE_URL=https://releases.mattermost.com/4.4.3/mattermost-4.4.3-linux-amd64.tar.gz
+SOURCE_SUM=589c53252d33f32539d98b0a5fbe9af29fbd80e46ea79e1d156b81b743151ce2
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-4.4.2-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-4.4.3-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran, 

Mattermost v4.4.3 release is officially out.  

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/5kc3brcq3irbdf3pmi1enffb7h).  Changelog in progress with notes on patch releases is available [here](https://github.com/mattermost/docs/pull/1668).

If you do update, please consider tweeting about it, which we can then re-tweet for greater reach.

Thanks!