### PR TITLE
Propose updating to Mattermost 4.4.5

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/4.4.3/mattermost-4.4.3-linux-amd64.tar.gz
-SOURCE_SUM=589c53252d33f32539d98b0a5fbe9af29fbd80e46ea79e1d156b81b743151ce2
+SOURCE_URL=https://releases.mattermost.com/4.4.5/mattermost-4.4.5-linux-amd64.tar.gz
+SOURCE_SUM=54c268cb1ace376981ffc6845b18185c287783fad4dfb90969cd6bc459e306ae
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-4.4.3-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-4.4.5-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v4.4.5 release is officially out.  The release contains a medium severity security fix. Upgrading is highly recommended although you might wish to wait and upgrade when v4.5 is released on Friday, 15 December.

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/buhd5ew387b1mm6bq4p8htm4wa).  Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html?highlight=changelog#release-v4-4-5).