### PR TITLE
Propose Updating to Mattermost v4.5

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/4.4.5/mattermost-4.4.5-linux-amd64.tar.gz
-SOURCE_SUM=54c268cb1ace376981ffc6845b18185c287783fad4dfb90969cd6bc459e306ae
+SOURCE_URL=https://releases.mattermost.com/4.5.0/mattermost-4.5.0-linux-amd64.tar.gz
+SOURCE_SUM=a3af246f160aaf06ce9706a566222a4470c9ec364ce1861492f35dc0a03f1360
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-4.4.5-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-4.5-linux-amd64.tar.gz


### PR DESCRIPTION
Hey @kemenaran, Mattermost v4.5 release is officially out!

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/9buqjpu6eidyxbd75xbjdn19zc).  Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html?highlight=changelog#release-v4-5).

Wondering if you'd like to help update Mattermost Yunohost to be compatible with Mattermost 4.5?

If you do update, please consider tweeting about it, which we can then re-tweet for greater reach.

Thanks!