### PR TITLE
Support multi-instances

### DIFF
--- a/check_process
+++ b/check_process
@@ -10,7 +10,7 @@
     ; Checks
         pkg_linter=1
         setup_root=1
-        setup_private=0
+        setup_private=1
         setup_public=1
         upgrade=1
         backup_restore=1

--- a/check_process
+++ b/check_process
@@ -1,10 +1,12 @@
 ;; Mattermost
     ; Manifest
-        domain="ynhtests.local"    (DOMAIN)
+        domain="ynhtests.local" (DOMAIN)
         path="" (PATH)
+        user="admin" (USER)
         language="fr"
         is_public=1 (PUBLIC|public=1|private=0)
-        password="alpine"    (PASSWORD)
+        password="alpine"
+        port="8065" (PORT)
     ; Checks
         pkg_linter=1
         setup_root=1

--- a/check_process
+++ b/check_process
@@ -13,7 +13,7 @@
         setup_public=1
         upgrade=1
         backup_restore=1
-        multi_instance=0
+        multi_instance=1
         port_already_use=1 (8085)
         # Checks not supported yet
         change_url=0

--- a/check_process
+++ b/check_process
@@ -6,7 +6,6 @@
         language="fr"
         is_public=1 (PUBLIC|public=1|private=0)
         password="alpine"
-        port="8065" (PORT)
     ; Checks
         pkg_linter=1
         setup_root=1
@@ -15,9 +14,10 @@
         upgrade=1
         backup_restore=1
         multi_instance=0
-        port_already_use=0 (XXXX)
+        port_already_use=1 (8085)
+        # Checks not supported yet
         change_url=0
-        # Tests not applicable
+        # Checks not applicable
         setup_sub_dir=0
         setup_nourl=0
         incorrect_path=0

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -12,7 +12,7 @@ location ~ /api/v[0-9]+/(users/)?websocket$ {
     proxy_buffers 256 16k;
     proxy_buffer_size 16k;
     proxy_read_timeout 600s;
-    proxy_pass http://127.0.0.1:8065;
+    proxy_pass http://127.0.0.1:__PORT__;
 }
 
 location / {
@@ -33,7 +33,7 @@ location / {
     #proxy_cache_min_uses 2;
     #proxy_cache_use_stale timeout;
     #proxy_cache_lock on;
-    proxy_pass http://127.0.0.1:8065;
+    proxy_pass http://127.0.0.1:__PORT__;
     # Yunohost addition: redirect HTTP to HTTPS
     if ($scheme = http) {
         rewrite ^ https://$server_name$request_uri? permanent;

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -12,7 +12,7 @@ ExecStart=__FINALPATH__/bin/platform
 #
 # TODO: improve mattermost to send a STARTED notification, and
 # switch the service to 'Type=notify' instead.
-ExecStartPost=/usr/bin/timeout 10 /bin/sh -c 'while ! nc -z localhost 8065; do sleep 0.2; done'
+ExecStartPost=/usr/bin/timeout 10 /bin/sh -c 'while ! nc -z localhost __PORT__; do sleep 0.2; done'
 Restart=always
 RestartSec=10
 WorkingDirectory=__FINALPATH__

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
         "name": "pmorinerie",
         "email": "kemenaran@gmail.com"
     },
-    "multi_instance": false,
+    "multi_instance": true,
     "services": [
         "nginx"
     ],

--- a/manifest.json
+++ b/manifest.json
@@ -32,13 +32,13 @@
                 "example": "domain.org"
             },
             {
-                "name": "public_site",
+                "name": "is_public",
+                "type": "boolean",
                 "ask": {
                     "en": "Can guest users access this chat?",
                     "fr": "Les utilisateurs non-enregistrés peuvent-ils accéder à ce chat ?"
                 },
-                "choices": ["Yes", "No"],
-                "default": "Yes"
+                "default": true
             },
             {
                 "name": "analytics",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Add a systemd configuration using ynh_add_systemd_config,
+# by replacing __PORT__ with the $port variable value.
+mattermost_add_systemd_config () {
+  local config_path="../conf"
+
+  # Replace variables in the systemd template config file
+  sed -i'.template' "s/__PORT__/$port/g" "$config_path/systemd.service"
+
+  # Create a dedicated systemd config
+  ynh_add_systemd_config
+
+  # Restore the original configuration template
+  rm "$config_path/systemd.service"
+  mv "$config_path/systemd.service.template" "$config_path/systemd.service"
+}

--- a/scripts/install
+++ b/scripts/install
@@ -91,19 +91,20 @@ logs_path="/var/log/$app"
 # CREATE A MYSQL DATABASE
 #=================================================
 
-db_name="mattermost"
+db_name="$app"
 db_user="mmuser"
 db_password=$(dd if=/dev/urandom bs=1 count=200 2> /dev/null | tr -c -d 'A-Za-z0-9' | sed -n 's/\(.\{24\}\).*/\1/p')
-ynh_mysql_create_db $db_name $db_user $db_password
-ynh_app_setting_set mattermost mysqlpwd "$db_password"
+ynh_mysql_create_db "$db_name" "$db_user" "$db_password"
+ynh_app_setting_set "$app" mysqlpwd "$db_password"
 
 #=================================================
 # CREATE USER FOR EMAIL NOTIFICATIONS
 #=================================================
 
+smtp_user="$app"
 smtp_password=$(dd if=/dev/urandom bs=1 count=200 2> /dev/null | tr -c -d 'A-Za-z0-9' | sed -n 's/\(.\{24\}\).*/\1/p')
-sudo useradd -M --shell /bin/false -p $(openssl passwd -1 "$smtp_password") "mattermost"
-ynh_app_setting_set mattermost smtppwd "$smtp_password"
+sudo useradd -M --shell /bin/false -p $(openssl passwd -1 "$smtp_password") "$smtp_user"
+ynh_app_setting_set "$app" smtppwd "$smtp_password"
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
@@ -131,7 +132,7 @@ sudo sed -i "s|\"Directory\": \"./data/\"|\"Directory\": \"${data_path}/\"|g"   
 sudo sed -i "s|\"SendEmailNotifications\": false|\"SendEmailNotifications\": true|g"   $final_path/config/config.json
 sudo sed -i "s|\"FeedbackName\": \"\"|\"FeedbackName\": \"Mattermost notification\"|g" $final_path/config/config.json
 sudo sed -i "s|\"FeedbackEmail\": \"\"|\"FeedbackEmail\": \"no-reply@${domain}\"|g"    $final_path/config/config.json
-sudo sed -i "s|\"SMTPUsername\": \"\"|\"SMTPUsername\": \"mattermost\"|g"              $final_path/config/config.json
+sudo sed -i "s|\"SMTPUsername\": \"\"|\"SMTPUsername\": \"${smtp_user}\"|g"            $final_path/config/config.json
 sudo sed -i "s|\"SMTPPassword\": \"\"|\"SMTPPassword\": \"${smtp_password}\"|g"        $final_path/config/config.json
 sudo sed -i "s|\"SMTPServer\": \"\"|\"SMTPServer\": \"localhost\"|g"                   $final_path/config/config.json
 sudo sed -i "s|\"SMTPPort\": \"\"|\"SMTPPort\": \"25\"|g"                              $final_path/config/config.json
@@ -149,9 +150,9 @@ ynh_app_setting_set "$app" analytics "$analytics"
 # SECURE FILES AND DIRECTORIES
 #=================================================
 
-sudo chown -R mattermost:www-data "$final_path"
-sudo chown -R mattermost:www-data "$data_path"
-sudo chown -R mattermost:adm      "$logs_path"
+sudo chown -R "$smtp_user:www-data" "$final_path"
+sudo chown -R "$smtp_user:www-data" "$data_path"
+sudo chown -R "$smtp_user:adm"      "$logs_path"
 
 #=================================================
 # NGINX CONFIGURATION
@@ -192,4 +193,4 @@ sudo systemctl reload nginx
 # START SERVER
 #=================================================
 
-sudo systemctl start mattermost
+sudo systemctl start "$app"

--- a/scripts/install
+++ b/scripts/install
@@ -101,10 +101,10 @@ ynh_app_setting_set "$app" mysqlpwd "$db_password"
 # CREATE USER FOR EMAIL NOTIFICATIONS
 #=================================================
 
-smtp_user="$app"
-smtp_password=$(dd if=/dev/urandom bs=1 count=200 2> /dev/null | tr -c -d 'A-Za-z0-9' | sed -n 's/\(.\{24\}\).*/\1/p')
-sudo useradd -M --shell /bin/false -p $(openssl passwd -1 "$smtp_password") "$smtp_user"
-ynh_app_setting_set "$app" smtppwd "$smtp_password"
+mattermost_user="$app"
+mattermost_user_password=$(dd if=/dev/urandom bs=1 count=200 2> /dev/null | tr -c -d 'A-Za-z0-9' | sed -n 's/\(.\{24\}\).*/\1/p')
+sudo useradd -M --shell /bin/false -p $(openssl passwd -1 "$mattermost_user_password") "$mattermost_user"
+ynh_app_setting_set "$app" smtppwd "$mattermost_user_password"
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
@@ -121,25 +121,25 @@ sudo mkdir -p "$logs_path"
 #=================================================
 
 # Configure Service Settings
-sudo sed -i "s|\"SiteURL\": \"\"|\"SiteURL\": \"https://${domain}${path_url}\"|g"      $final_path/config/config.json
-sudo sed -i "s|\"ListenAddress\": \".*\"|\"ListenAddress\": \"127.0.0.1:${port}\"|g"   $final_path/config/config.json
+sudo sed -i "s|\"SiteURL\": \"\"|\"SiteURL\": \"https://${domain}${path_url}\"|g"          $final_path/config/config.json
+sudo sed -i "s|\"ListenAddress\": \".*\"|\"ListenAddress\": \"127.0.0.1:${port}\"|g"       $final_path/config/config.json
 # Configure the database connection
 db_connection_url="${db_user}:${db_password}@tcp(127.0.0.1:3306)/${db_name}?charset=utf8mb4,utf8"
-sudo sed -i "s|\"DataSource\": \".*\"|\"DataSource\": \"${db_connection_url}\"|g"      $final_path/config/config.json
+sudo sed -i "s|\"DataSource\": \".*\"|\"DataSource\": \"${db_connection_url}\"|g"          $final_path/config/config.json
 # Configure uploaded files directory
-sudo sed -i "s|\"Directory\": \"./data/\"|\"Directory\": \"${data_path}/\"|g"          $final_path/config/config.json
+sudo sed -i "s|\"Directory\": \"./data/\"|\"Directory\": \"${data_path}/\"|g"              $final_path/config/config.json
 # Configure SMTP account for sending email notifications
-sudo sed -i "s|\"SendEmailNotifications\": false|\"SendEmailNotifications\": true|g"   $final_path/config/config.json
-sudo sed -i "s|\"FeedbackName\": \"\"|\"FeedbackName\": \"Mattermost notification\"|g" $final_path/config/config.json
-sudo sed -i "s|\"FeedbackEmail\": \"\"|\"FeedbackEmail\": \"no-reply@${domain}\"|g"    $final_path/config/config.json
-sudo sed -i "s|\"SMTPUsername\": \"\"|\"SMTPUsername\": \"${smtp_user}\"|g"            $final_path/config/config.json
-sudo sed -i "s|\"SMTPPassword\": \"\"|\"SMTPPassword\": \"${smtp_password}\"|g"        $final_path/config/config.json
-sudo sed -i "s|\"SMTPServer\": \"\"|\"SMTPServer\": \"localhost\"|g"                   $final_path/config/config.json
-sudo sed -i "s|\"SMTPPort\": \"\"|\"SMTPPort\": \"25\"|g"                              $final_path/config/config.json
+sudo sed -i "s|\"SendEmailNotifications\": false|\"SendEmailNotifications\": true|g"       $final_path/config/config.json
+sudo sed -i "s|\"FeedbackName\": \"\"|\"FeedbackName\": \"Mattermost notification\"|g"     $final_path/config/config.json
+sudo sed -i "s|\"FeedbackEmail\": \"\"|\"FeedbackEmail\": \"no-reply@${domain}\"|g"        $final_path/config/config.json
+sudo sed -i "s|\"SMTPUsername\": \"\"|\"SMTPUsername\": \"${mattermost_user}\"|g"          $final_path/config/config.json
+sudo sed -i "s|\"SMTPPassword\": \"\"|\"SMTPPassword\": \"${mattermost_user_password}\"|g" $final_path/config/config.json
+sudo sed -i "s|\"SMTPServer\": \"\"|\"SMTPServer\": \"localhost\"|g"                       $final_path/config/config.json
+sudo sed -i "s|\"SMTPPort\": \"\"|\"SMTPPort\": \"25\"|g"                                  $final_path/config/config.json
 # Disable Mattermost debug console by default
-sudo sed -i "s|\"EnableConsole\": true|\"EnableConsole\": false|g"                     $final_path/config/config.json
+sudo sed -i "s|\"EnableConsole\": true|\"EnableConsole\": false|g"                         $final_path/config/config.json
 # Configure log file location
-sudo sed -i "s|\"FileLocation\": \"\"|\"FileLocation\": \"$logs_path\"|g"              $final_path/config/config.json
+sudo sed -i "s|\"FileLocation\": \"\"|\"FileLocation\": \"$logs_path\"|g"                  $final_path/config/config.json
 # Configure analytics according to user choice
 if [ $analytics -eq 0 ]; then
     sudo sed -i "s|\"EnableDiagnostics\": true|\"EnableDiagnostics\": false|g"             $final_path/config/config.json
@@ -150,9 +150,9 @@ ynh_app_setting_set "$app" analytics "$analytics"
 # SECURE FILES AND DIRECTORIES
 #=================================================
 
-sudo chown -R "$smtp_user:www-data" "$final_path"
-sudo chown -R "$smtp_user:www-data" "$data_path"
-sudo chown -R "$smtp_user:adm"      "$logs_path"
+sudo chown -R "$mattermost_user:www-data" "$final_path"
+sudo chown -R "$mattermost_user:www-data" "$data_path"
+sudo chown -R "$mattermost_user:adm"      "$logs_path"
 
 #=================================================
 # NGINX CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -6,6 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
+source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -55,14 +56,27 @@ then
     script_die "Mattermost requires MySQL 5.6 or higher, or MariaDB 10 or higher."
 fi
 
+#=================================================
+# FIND AN AVAILABLE PATH
+#=================================================
+
 # Normalize the url path syntax
 path_url=$(ynh_normalize_url_path $path_url)
 # Check web path availability
-ynh_webpath_available $domain $path_url
+ynh_webpath_available "$domain" "$path_url"
 # Register (book) web path
-ynh_webpath_register $app $domain $path_url
+ynh_webpath_register "$app" "$domain" "$path_url"
 # Store setting
 ynh_app_setting_set "$app" domain "$domain"
+
+#=================================================
+# FIND AN AVAILABLE PORT
+#=================================================
+
+# Find an available port
+port=$(ynh_find_port 8065)
+# Store setting
+ynh_app_setting_set "$app" port "$port"
 
 #=================================================
 # SET UP INSTALLATION VARIABLES
@@ -107,6 +121,7 @@ sudo mkdir -p "$logs_path"
 
 # Configure Service Settings
 sudo sed -i "s|\"SiteURL\": \"\"|\"SiteURL\": \"https://${domain}${path_url}\"|g"      $final_path/config/config.json
+sudo sed -i "s|\"ListenAddress\": \".*\"|\"ListenAddress\": \"127.0.0.1:${port}\"|g"   $final_path/config/config.json
 # Configure the database connection
 db_connection_url="${db_user}:${db_password}@tcp(127.0.0.1:3306)/${db_name}?charset=utf8mb4,utf8"
 sudo sed -i "s|\"DataSource\": \".*\"|\"DataSource\": \"${db_connection_url}\"|g"      $final_path/config/config.json
@@ -142,15 +157,13 @@ sudo chown -R mattermost:adm      "$logs_path"
 # NGINX CONFIGURATION
 #=================================================
 
-# Copy conf/nginx.conf to the correct location
 ynh_add_nginx_config
 
 #=================================================
 # SYSTEMD CONFIGURATION
 #=================================================
 
-# Create a dedicated systemd config
-ynh_add_systemd_config
+mattermost_add_systemd_config
 
 #=================================================
 # ADVERTISE SERVICE IN ADMIN PANEL

--- a/scripts/install
+++ b/scripts/install
@@ -21,7 +21,7 @@ ynh_abort_if_errors
 
 app=$YNH_APP_INSTANCE_NAME
 domain=$YNH_APP_ARG_DOMAIN
-is_public=$YNH_APP_ARG_PUBLIC_SITE
+is_public=$YNH_APP_ARG_IS_PUBLIC
 analytics=$YNH_APP_ARG_ANALYTICS
 path_url="/"
 
@@ -163,11 +163,11 @@ sudo yunohost service add "$app" --log "$logs_path/mattermost.log"
 #=================================================
 
 ynh_app_setting_set "$app" is_public "$is_public"
-if [ "$is_public" = "Yes" ];
-then
+
+if [[ $is_public == "1" ]]; then
+    # Make the app accessible to the public
     ynh_app_setting_set "$app" unprotected_uris "/"
 fi
-sudo yunohost app ssowatconf
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/remove
+++ b/scripts/remove
@@ -14,9 +14,10 @@ source /usr/share/yunohost/helpers
 #=================================================
 
 app=$YNH_APP_INSTANCE_NAME
-domain=$(ynh_app_setting_get mattermost domain)
-db_name="mattermost"
+domain=$(ynh_app_setting_get $app domain)
+db_name="$app"
 db_user="mmuser"
+smtp_user="$app"
 final_path="/var/www/$app"
 data_path="/home/yunohost.app/$app"
 logs_path="/var/log/$app"
@@ -76,4 +77,4 @@ sudo rm -rf "$logs_path"
 # REMOVE DEDICATED USER
 #=================================================
 
-ynh_system_user_delete "$app"
+ynh_system_user_delete "$smtp_user"

--- a/scripts/remove
+++ b/scripts/remove
@@ -17,7 +17,7 @@ app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get $app domain)
 db_name="$app"
 db_user="mmuser"
-smtp_user="$app"
+mattermost_user="$app"
 final_path="/var/www/$app"
 data_path="/home/yunohost.app/$app"
 logs_path="/var/log/$app"
@@ -77,4 +77,4 @@ sudo rm -rf "$logs_path"
 # REMOVE DEDICATED USER
 #=================================================
 
-ynh_system_user_delete "$smtp_user"
+ynh_system_user_delete "$mattermost_user"

--- a/scripts/restore
+++ b/scripts/restore
@@ -93,9 +93,12 @@ sudo chown -R mattermost:adm "$logs_path"
 # RESTORE SSOWAT
 #=================================================
 
-if [ "$is_public" = "Yes" ];
-then
+if [[ $is_public == "1" ]]; then
+  # Make the app accessible to the public
   ynh_app_setting_set "$app" unprotected_uris "/"
+else
+  # Remove the public access
+  ynh_app_setting_delete "$app" skipped_uris
 fi
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -27,6 +27,7 @@ data_path="/home/yunohost.app/$app"
 logs_path="/var/log/$app"
 db_name="$app"
 db_user="mmuser"
+smtp_user="$app"
 
 #=================================================
 # CHECK IF THE APP CAN BE RESTORED
@@ -62,8 +63,8 @@ ynh_restore_file "$data_path"
 #=================================================
 
 db_pwd=$(ynh_app_setting_get $app mysqlpwd)
-ynh_mysql_setup_db $db_user $db_name $db_pwd
-ynh_mysql_connect_as $db_user $db_pwd $db_name < ./db.sql
+ynh_mysql_setup_db "$db_user" "$db_name" "$db_pwd"
+ynh_mysql_connect_as "$db_user" "$db_pwd" "$db_name" < ./db.sql
 
 #=================================================
 # RECREATE THE DEDICATED USER
@@ -81,13 +82,13 @@ fi
 #=================================================
 
 # Restore permissions on app files
-sudo chown -R mattermost:www-data "$final_path"
+sudo chown -R "$smtp_user:www-data" "$final_path"
 
 mkdir -p "$data_path"
-sudo chown -R mattermost:www-data "$data_path"
+sudo chown -R "$smtp_user:www-data" "$data_path"
 
 mkdir -p "$logs_path"
-sudo chown -R mattermost:adm "$logs_path"
+sudo chown -R "$smtp_user:adm" "$logs_path"
 
 #=================================================
 # RESTORE SSOWAT

--- a/scripts/restore
+++ b/scripts/restore
@@ -72,7 +72,7 @@ ynh_mysql_connect_as $db_user $db_pwd $db_name < ./db.sql
 # Create the dedicated user (if not existing)
 smtp_user="$app"
 if ! ynh_system_user_exists "$smtp_user"; then
-  smtp_password=$(ynh_app_setting_get $app smtp_password)
+  smtp_password=$(ynh_app_setting_get $app smtppwd)
   useradd -M --shell /bin/false -p $(openssl passwd -1 "$smtp_password") "$smtp_user"
 fi
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -27,7 +27,7 @@ data_path="/home/yunohost.app/$app"
 logs_path="/var/log/$app"
 db_name="$app"
 db_user="mmuser"
-smtp_user="$app"
+mattermost_user="$app"
 
 #=================================================
 # CHECK IF THE APP CAN BE RESTORED
@@ -71,10 +71,10 @@ ynh_mysql_connect_as "$db_user" "$db_pwd" "$db_name" < ./db.sql
 #=================================================
 
 # Create the dedicated user (if not existing)
-smtp_user="$app"
-if ! ynh_system_user_exists "$smtp_user"; then
-  smtp_password=$(ynh_app_setting_get $app smtppwd)
-  useradd -M --shell /bin/false -p $(openssl passwd -1 "$smtp_password") "$smtp_user"
+mattermost_user="$app"
+if ! ynh_system_user_exists "$mattermost_user"; then
+  mattermost_user_password=$(ynh_app_setting_get $app smtppwd)
+  useradd -M --shell /bin/false -p $(openssl passwd -1 "$mattermost_user_password") "$mattermost_user"
 fi
 
 #=================================================
@@ -82,13 +82,13 @@ fi
 #=================================================
 
 # Restore permissions on app files
-sudo chown -R "$smtp_user:www-data" "$final_path"
+sudo chown -R "$mattermost_user:www-data" "$final_path"
 
 mkdir -p "$data_path"
-sudo chown -R "$smtp_user:www-data" "$data_path"
+sudo chown -R "$mattermost_user:www-data" "$data_path"
 
 mkdir -p "$logs_path"
-sudo chown -R "$smtp_user:adm" "$logs_path"
+sudo chown -R "$mattermost_user:adm" "$logs_path"
 
 #=================================================
 # RESTORE SSOWAT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -21,9 +21,10 @@ ynh_abort_if_errors
 #=================================================
 
 app=$YNH_APP_INSTANCE_NAME
-domain=$(ynh_app_setting_get mattermost domain)
-is_public=$(ynh_app_setting_get mattermost is_public)
-port=$(ynh_app_setting_get mattermost port)
+domain=$(ynh_app_setting_get $app domain)
+is_public=$(ynh_app_setting_get $app is_public)
+port=$(ynh_app_setting_get $app port)
+smtp_user="$app"
 
 root_path="$(pwd)/.."
 final_path="/var/www/$app"
@@ -143,9 +144,9 @@ fi
 # RESTORE FILE PERMISSIONS
 #=================================================
 
-sudo chown -R mattermost:www-data "$final_path"
-sudo chown -R mattermost:www-data "$data_path"
-sudo chown -R mattermost:adm      "$logs_path"
+sudo chown -R "$smtp_user:www-data" "$final_path"
+sudo chown -R "$smtp_user:www-data" "$data_path"
+sudo chown -R "$smtp_user:adm"      "$logs_path"
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,7 +24,7 @@ app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get $app domain)
 is_public=$(ynh_app_setting_get $app is_public)
 port=$(ynh_app_setting_get $app port)
-smtp_user="$app"
+mattermost_user="$app"
 
 root_path="$(pwd)/.."
 final_path="/var/www/$app"
@@ -144,9 +144,9 @@ fi
 # RESTORE FILE PERMISSIONS
 #=================================================
 
-sudo chown -R "$smtp_user:www-data" "$final_path"
-sudo chown -R "$smtp_user:www-data" "$data_path"
-sudo chown -R "$smtp_user:adm"      "$logs_path"
+sudo chown -R "$mattermost_user:www-data" "$final_path"
+sudo chown -R "$mattermost_user:www-data" "$data_path"
+sudo chown -R "$mattermost_user:adm"      "$logs_path"
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -6,6 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
+source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -22,6 +23,7 @@ ynh_abort_if_errors
 app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get mattermost domain)
 is_public=$(ynh_app_setting_get mattermost is_public)
+port=$(ynh_app_setting_get mattermost port)
 
 root_path="$(pwd)/.."
 final_path="/var/www/$app"
@@ -57,7 +59,7 @@ if $(sudo systemctl -q is-active "$app"); then
   sudo systemctl stop "$app"
 fi
 
-# Legacy, for older versions of this app which used supervisor
+# Legacy, for previous versions of this app which used supervisor
 if [ -f "/etc/supervisor/conf.d/${app}.conf" ]; then
   sudo supervisorctl stop "$app"
   sudo rm -f "/etc/supervisor/conf.d/${app}.conf"
@@ -84,6 +86,12 @@ elif [[ $is_public == "No" ]]; then
 fi
 ynh_app_setting_set "$app" is_public "$is_public"
 
+# Save the port used if not present
+if ! [[ "$port" ]]; then
+  port=8065
+  ynh_app_setting_set "$app" port "$port"
+fi
+
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
@@ -107,7 +115,7 @@ ynh_add_nginx_config
 # SYSTEMD CONFIGURATION
 #=================================================
 
-ynh_add_systemd_config
+mattermost_add_systemd_config
 
 #=================================================
 # ADVERTISE SERVICE IN ADMIN PANEL

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -73,6 +73,18 @@ backup_config_file="/tmp/config.json"
 sudo cp -f "$config_file" "$backup_config_file"
 
 #=================================================
+# MIGRATE SETTINGS FROM PREVIOUS VERSIONS
+#=================================================
+
+# Convert is_public from "Yes"/"No" to 1 / 0
+if [[ $is_public == "Yes" ]]; then
+  is_public=1
+elif [[ $is_public == "No" ]]; then
+  is_public=0
+fi
+ynh_app_setting_set "$app" is_public "$is_public"
+
+#=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 


### PR DESCRIPTION
Multi-instances in the ability to install the app several times on the same Yunohost machine.

It is not very useful for Mattermost, as the app already support the creation of different teams (with greater flexibility). But it can help in order to have one domain per team.

This PR also:

- adds support for automatically selecting a different port when the default port is already used ;
- cleanup some scripts

Fix #84 
