### PR TITLE
Propose updating to Mattermost v4.6.1

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/4.6.0/mattermost-4.6.0-linux-amd64.tar.gz
-SOURCE_SUM=1865fbee3cd00659e56b178f766aff6eac6be2f4062b08a09fd66e801e687be1
+SOURCE_URL=https://releases.mattermost.com/4.6.1/mattermost-4.6.1-linux-amd64.tar.gz
+SOURCE_SUM=38ab2cbeb7e0759fe156819690b17b52d5a3cff5c08e155a01af3763e335f19d
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-4.6-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-4.6.1-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Here's a quick pull request updating to v4.6.1

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/fnhridds6fybbg4w8s4frdhpny).  Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html#release-v4-6).