### PR TITLE
upgrade: attempt to restore backup only if it was correctly saved

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -36,16 +36,32 @@ logs_path="/var/log/$app"
 #=================================================
 
 # Backup the current version of the app
-ynh_backup_before_upgrade
+# (NB: `tee` uses process substitution rather than a pipe,
+# to avoid spawning a subshell that would not save global
+# variables defined by `ynh_backup_before_upgrade`.)
+ynh_backup_before_upgrade > >(tee "upgrade.log")
+# Ensure the backup can be restored
+if grep -q "mattermost: Warning$" "upgrade.log"; then
+  can_restore_backup=false
+else
+  can_restore_backup=true
+fi
 
 # If the upgrade fails…
 ynh_clean_setup () {
-  # Stop attempting to restart the app
-  if $(sudo systemctl -q is-active "$app"); then
-    sudo systemctl stop "$app"
+  if [ "$can_restore_backup" = true ]; then
+    # Stop attempting to restart the app
+    if $(sudo systemctl -q is-active "$app"); then
+      sudo systemctl stop "$app"
+    fi
+    # Restore the backup
+    ynh_restore_upgradebackup
+  
+  else
+    # Backup restoration is not available:
+    # let's try at least to restart the server.
+    sudo systemctl start "$app"
   fi
-  # Restore the backup
-  ynh_restore_upgradebackup
 }
 
 # Exit if an error occurs during the execution of the script


### PR DESCRIPTION
In the current state, an upgrade may end up removing the app.

This is because the new upgrade script backups the app before upgrading – and attempts to restore the backup in case of upgrade failure. This is a great safety feature provided by Yunohost, which really makes upgrades safer.

However, if an app is upgraded from a previous version where it did support backup _but not restore_, Yunohost will happily:

1. back up the app,
1. attempt to upgrade,
1. in case of error, start attempting to restore the backup,
1. delete the app entirely to make room for the to-be-restored backup,
1. fail at restoring because no restore script is present.

To fix this, the script now checks if the backup went successfully. When an error occurs, it attempts to restore the backup only if the backup process was successful.

Ref #90