### PR TITLE
Propose upgrading to Mattermost v4.7

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/4.6.1/mattermost-4.6.1-linux-amd64.tar.gz
-SOURCE_SUM=38ab2cbeb7e0759fe156819690b17b52d5a3cff5c08e155a01af3763e335f19d
+SOURCE_URL=https://releases.mattermost.com/4.7.0/mattermost-4.7.0-linux-amd64.tar.gz
+SOURCE_SUM=ff53968ef8ac0a44f9a2d21fde719930b8042801f22866bc25bad53503819abd
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-4.6.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-4.7.0-linux-amd64.tar.gz


### PR DESCRIPTION
Hey @kemenaran! 

Mattermost v4.7 release is officially out!

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/ezdkj88no7yd3qn4h5z3i8cbqr).  Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html#release-v4-7).