### PR TITLE
Propose upgrading to Mattermost v4.7.3

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/4.7.2/mattermost-4.7.2-linux-amd64.tar.gz
-SOURCE_SUM=947577631a94a003d660b4eb08f07585e0e1f93c3e5b63a8c30a72e0abcde9c1
+SOURCE_URL=https://releases.mattermost.com/4.7.3/mattermost-4.7.3-linux-amd64.tar.gz
+SOURCE_SUM=09a728ad189d2cf315d664fed7caf68fbf9af60f85e2619d308b5345e576293c
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-4.7.2-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-4.7.3-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v4.7.3 release is officially out.  It contains a security fix so upgrade is recommended.

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/usjficyphtnbmx7g8bxtbm8dwr).  Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html#release-v4-7).

Thanks for continuing to maintain Mattermost Yunohost!