### PR TITLE
Propose upgrading to Mattermost v4.8.0

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/4.7.3/mattermost-4.7.3-linux-amd64.tar.gz
-SOURCE_SUM=09a728ad189d2cf315d664fed7caf68fbf9af60f85e2619d308b5345e576293c
+SOURCE_URL=https://releases.mattermost.com/4.8.0/mattermost-4.8.0-linux-amd64.tar.gz
+SOURCE_SUM=1d6dda36592544b92905989a922ff4698d0a824c30483e0ecdf7233443001c25
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-4.7.3-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-4.8.0-linux-amd64.tar.gz


### PR DESCRIPTION
Hey @kemenaran! 

Mattermost v4.8.0 release is officially out.

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/57qfbxkdrid88ci7hpasrozwda).  Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html). (Note: changelog has been merged and will show up a little later.)

Thanks!