### PR TITLE
Propose upgrading to Mattermost v4.8.1

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/4.8.0/mattermost-4.8.0-linux-amd64.tar.gz
-SOURCE_SUM=1d6dda36592544b92905989a922ff4698d0a824c30483e0ecdf7233443001c25
+SOURCE_URL=https://releases.mattermost.com/4.8.1/mattermost-4.8.1-linux-amd64.tar.gz
+SOURCE_SUM=3dac9f9bb4884cd83b8274c2bd7c32418f2535d3f9911cea845ac047ee2c7a82
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-4.8.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-4.8.1-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v4.8.1 release is officially out.

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/iu1zaupajjdbtfcdjkm7q4bxqh). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!