### PR TITLE
Propose upgrading to Mattermost v4.9.0

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/4.8.1/mattermost-4.8.1-linux-amd64.tar.gz
-SOURCE_SUM=3dac9f9bb4884cd83b8274c2bd7c32418f2535d3f9911cea845ac047ee2c7a82
+SOURCE_URL=https://releases.mattermost.com/4.9.0/mattermost-4.9.0-linux-amd64.tar.gz
+SOURCE_SUM=484cdaec10a854366390d257f905279d66fe19f301c6a3065381773530ecaa5d
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-4.8.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-4.9.0-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v4.9.0 release is officially out.

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/bnwei9enhj873dkatrb6ptt3bo). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html?highlight=changelog#release-v4-9).

Thanks!