### PR TITLE
Propose Upgrading to Mattermost v.4.10.0

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/4.8.1/mattermost-4.8.1-linux-amd64.tar.gz
-SOURCE_SUM=3dac9f9bb4884cd83b8274c2bd7c32418f2535d3f9911cea845ac047ee2c7a82
+SOURCE_URL=https://releases.mattermost.com/4.10.0/mattermost-4.10.0-linux-amd64.tar.gz
+SOURCE_SUM=85baf856b10af2ac80866ace921ea38e2807b82d6800e90d273b63427b13d25d
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-4.8.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-4.10.0-linux-amd64.tar.gz


### PR DESCRIPTION
Mattermost v4.10.0 release is officially out!

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/bb88rb56fiy1mkqpr5moawd78w). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html?highlight=changelog#release-v4-10). 
