### PR TITLE
Upgrade to Mattermost 5.0.1

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/4.10.1/mattermost-4.10.1-linux-amd64.tar.gz
-SOURCE_SUM=cef8a706d6da1d8756d70d06a9e9444ba078fb107a194ce91ea2e6beae9726f7
+SOURCE_URL=https://releases.mattermost.com/5.0.1/mattermost-5.0.1-linux-amd64.tar.gz
+SOURCE_SUM=91f709a167a42f0f388e923737d1e0c9f19b3950c5c29e683d59b0fef1bf0ce6
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-4.10.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.0.1-linux-amd64.tar.gz

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -9,7 +9,7 @@ Requires=mysql.service
 
 [Service]
 Type=notify
-ExecStart=__FINALPATH__/bin/platform
+ExecStart=__FINALPATH__/bin/mattermost
 TimeoutStartSec=3600
 Restart=always
 RestartSec=10

--- a/scripts/install
+++ b/scripts/install
@@ -206,10 +206,10 @@ admin_username=$(cut -d @ -f 1 <<< "$admin_email")
 team_name=$(echo "$team_display_name" | iconv -f utf8 -t ascii//TRANSLIT//IGNORE | sed -e 's/[^[:alnum:]]/-/g' | tr -s '-' | tr A-Z a-z)
 
 cd "$final_path/bin"
-sudo ./platform user create --username "$admin_username" --email "$admin_email" --password "$admin_password" --locale "$admin_locale" --system_admin
-sudo ./platform user verify "$admin_username"
-sudo ./platform team create --name "$team_name" --display_name "$team_display_name" --email "$admin_email"
-sudo ./platform team add "$team_name" "$admin_username"
+sudo ./mattermost user create --username "$admin_username" --email "$admin_email" --password "$admin_password" --locale "$admin_locale" --system_admin
+sudo ./mattermost user verify "$admin_username"
+sudo ./mattermost team create --name "$team_name" --display_name "$team_display_name" --email "$admin_email"
+sudo ./mattermost team add "$team_name" "$admin_username"
 
 ynh_app_setting_set "$app" admin_email "$admin_email"
 ynh_app_setting_set "$app" admin_locale "$admin_locale"


### PR DESCRIPTION
- Update sources,
- Upgrade references to the deprecated `bin/platform` binary.

Replaces #117.