### PR TITLE
Propose upgrading to Mattermost v5.7.1

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.7.0/mattermost-5.7.0-linux-amd64.tar.gz
-SOURCE_SUM=1220e25f501e41db9bee6af14dd12583c1f95658a55862da42a1268d160b10c4
+SOURCE_URL=https://releases.mattermost.com/5.7.1/mattermost-5.7.1-linux-amd64.tar.gz
+SOURCE_SUM=09f4068e12e435433276172c1a25b0cb74e354687787e781cba7a6c5467bab67
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.7.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.7.1-linux-amd64.tar.gz


### PR DESCRIPTION
We just released a security dot release, more details on the Changelog: https://docs.mattermost.com/administration/changelog.html#release-v5-7.