### PR TITLE
Propose Upgrading to Mattermost v5.9.0

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.7.1/mattermost-5.7.1-linux-amd64.tar.gz
-SOURCE_SUM=09f4068e12e435433276172c1a25b0cb74e354687787e781cba7a6c5467bab67
+SOURCE_URL=https://releases.mattermost.com/5.9.0/mattermost-5.9.0-linux-amd64.tar.gz
+SOURCE_SUM=bc8e6ee168d658ed008b3006b979a609482c68de00b447885c2e255e792ddaa7
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.7.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.9.0-linux-amd64.tar.gz


### PR DESCRIPTION
Mattermost v5.9.0 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/5s3wiaogzf8ftke8ge574ik78a). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!