### PR TITLE
Propose Upgrading to Mattermost v5.10.0

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.9.0/mattermost-5.9.0-linux-amd64.tar.gz
-SOURCE_SUM=bc8e6ee168d658ed008b3006b979a609482c68de00b447885c2e255e792ddaa7
+SOURCE_URL=https://releases.mattermost.com/5.10.0/mattermost-5.10.0-linux-amd64.tar.gz
+SOURCE_SUM=210416d6def6424e33b358c2f5808adfbdf15adf3ffba6768d16d7777230b24f
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.9.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.10.0-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.10.0 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/u6hyeq39rpny9n7yf58js4ptyc). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!