### PR TITLE
Propose Upgrading to Mattermost v5.11.0

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.10.0/mattermost-5.10.0-linux-amd64.tar.gz
-SOURCE_SUM=210416d6def6424e33b358c2f5808adfbdf15adf3ffba6768d16d7777230b24f
+SOURCE_URL=https://releases.mattermost.com/5.11.0/mattermost-5.11.0-linux-amd64.tar.gz
+SOURCE_SUM=ad2db1a68103fb3ce9383f857eddc817848d548334b510b2dd2491f13f59ea4d
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.10.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.11.0-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.11.0 release is officially out.

You can find download links with hash numbers [here](https://community-daily.mattermost.com/core/pl/wnia1ig64fbtjn8caj7uoojkco). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!