### PR TITLE
Upgrade to Mattermost v5.12.1

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.12.0/mattermost-5.12.0-linux-amd64.tar.gz
-SOURCE_SUM=ce4b1b182e12ca499ba3e1a115f7635e0747430b741b3e10b4de54b8bcbfdfd7
+SOURCE_URL=https://releases.mattermost.com/5.12.1/mattermost-5.12.1-linux-amd64.tar.gz
+SOURCE_SUM=74381e50a8cffb89e5d75390aea0068da38489056eb2bd99e4b8f4ff83078a9c
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.12.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.12.1-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.12.1 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/e1at5qifw3demcbji8sn14f1zo). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!