### PR TITLE
Improve password policy

### DIFF
--- a/check_process
+++ b/check_process
@@ -3,7 +3,7 @@
         domain="ynhtests.local" (DOMAIN)
         path="" (PATH)
         admin_email="john@gmail.com"
-        admin_password="mattermost_password"
+        admin_password="MattermostPassword!42"
         admin_locale="fr"
         team_display_name="Mon équipe"
         is_public=1 (PUBLIC|public=1|private=0)

--- a/manifest.json
+++ b/manifest.json
@@ -53,8 +53,8 @@
                 "name": "admin_password",
                 "type": "password",
                 "ask": {
-                    "en": "Password for the chat admin",
-                    "fr": "Mot de passe pour l’administrateur du chat"
+                    "en": "Password for the chat admin. Must contain at least 10 characters, one lowercase letter, one uppercase letter, one number, and one symbol (e.g. '~!@#$%^&*()').",
+                    "fr": "Mot de passe pour l’administrateur du chat. Doit contenir au moins 10 caractères, une majuscule, une minuscule, un chiffre, et une ponctuation (ex. '~!@#$%^&*()')."
                 },
                 "optional": false
             },


### PR DESCRIPTION
Mattermost has a password complexity policy for admin passwords.

- Explain this policy to the user in the setup screen
- Fix the CI, by complying with the policy