### PR TITLE
Upgrade to Mattermost v5.16.2

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.16.1/mattermost-5.16.1-linux-amd64.tar.gz
-SOURCE_SUM=1ca1c334607bb089737357c3ec79384e79f0c47480966e5794e32e0742472983
+SOURCE_URL=https://releases.mattermost.com/5.16.2/mattermost-5.16.2-linux-amd64.tar.gz
+SOURCE_SUM=dceae9bbbfb9609d1f6a6c9ca141748196860239ea1a9e8ef1888949951f2c8c
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.16.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.16.2-linux-amd64.tar.gz

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.14.2/mattermost-5.14.2-linux-amd64.tar.gz
-SOURCE_SUM=957809e1b494d77121274dd4b8059e676c48c18d29c388a5b35bebfa96637335
+SOURCE_URL=https://releases.mattermost.com/5.16.1/mattermost-5.16.1-linux-amd64.tar.gz
+SOURCE_SUM=1ca1c334607bb089737357c3ec79384e79f0c47480966e5794e32e0742472983
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.14.2-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.16.1-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran, Mattermost v5.16.2 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/9e7ah4kqb7fuumsqo48a3ofjqh). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html). Note that the previous dot release, v5.16.1, included a high level security fix and upgrading is recommended.

Thanks!