### PR TITLE
Upgrade to Mattermost v5.16.3

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.16.2/mattermost-5.16.2-linux-amd64.tar.gz
-SOURCE_SUM=dceae9bbbfb9609d1f6a6c9ca141748196860239ea1a9e8ef1888949951f2c8c
+SOURCE_URL=https://releases.mattermost.com/5.16.3/mattermost-5.16.3-linux-amd64.tar.gz
+SOURCE_SUM=b564a480e56112925289c413dbdd2d8d66b6b98fad64d659f43e9a16a6fcf1a7
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.16.2-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.16.3-linux-amd64.tar.gz


### PR DESCRIPTION
@kemenaran Mattermost v5.16.3 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/xrz8fgmy1b8y7e394oe4yew1xo). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!