### PR TITLE
Upgrade to Mattermost v5.18.0

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.17.1/mattermost-5.17.1-linux-amd64.tar.gz
-SOURCE_SUM=2da727da93b0d193eb3dfdfadb2534eb43dbbf68bce84074d3cc89619bb8f263
+SOURCE_URL=https://releases.mattermost.com/5.18.0/mattermost-5.18.0-linux-amd64.tar.gz
+SOURCE_SUM=a90fdccd929cb1ce52c5f1666b01381d4659ece5069bd8d856107bdfcc930570
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.17.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.18.0-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.18.0 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/uambj4orzbfapdp5ufndjr3kkh). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!