### PR TITLE
Upgrade to Mattermost v5.20.1

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.19.1/mattermost-5.19.1-linux-amd64.tar.gz
-SOURCE_SUM=fe4bf2dc184c17daab3164f68b2e73cc460d60e7c3877b309844240581d13d97
+SOURCE_URL=https://releases.mattermost.com/5.20.1/mattermost-5.20.1-linux-amd64.tar.gz
+SOURCE_SUM=b9d07c6de14175e2a29625c8c9f0d394ba652e97878cc0e84838ac2138bc2d10
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.19.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.20.1-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.20.1 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/7qb4m53zmirp5kyphacfz7y9ca). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!