### PR TITLE
FIX the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -44,7 +44,7 @@
             {
                 "name": "is_public",
                 "type": "boolean",
-                "help": {
+                "ask": {
                     "en": "Can users non registered on Yunohost access this chat?",
                     "fr": "Les invités non-enregistrés sur Yunohost peuvent-ils accéder à ce chat ?"
                 },


### PR DESCRIPTION
The application list builder fails if there is no "ask" key.