### PR TITLE
Upgrade to Mattermost v5.21.0

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.19.1/mattermost-5.19.1-linux-amd64.tar.gz
-SOURCE_SUM=fe4bf2dc184c17daab3164f68b2e73cc460d60e7c3877b309844240581d13d97
+SOURCE_URL=https://releases.mattermost.com/5.21.0/mattermost-5.21.0-linux-amd64.tar.gz
+SOURCE_SUM=909b17498139cd511d4e5483e2b7be0b757ac28ea5063be9c3d82cbe49b4a696
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.19.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.21.0-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.21.0 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/ec8u1ys31f8xikhctdzmh8bahr). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!