### PR TITLE
Propose Upgrading to Mattermost v5.22.3

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.22.1/mattermost-5.22.1-linux-amd64.tar.gz
-SOURCE_SUM=f4387c393ed70a6674aa30e06ab832d2ef9878110f089e07319a4e314f625acd
+SOURCE_URL=https://releases.mattermost.com/5.22.2/mattermost-5.22.2-linux-amd64.tar.gz
+SOURCE_SUM=479a7a7be6fa70ace325acabf0d395dccdfe1065050b81c8b38dd0ef76cc7532
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.22.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.22.2-linux-amd64.tar.gz

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.22.2/mattermost-5.22.2-linux-amd64.tar.gz
-SOURCE_SUM=479a7a7be6fa70ace325acabf0d395dccdfe1065050b81c8b38dd0ef76cc7532
+SOURCE_URL=https://releases.mattermost.com/5.22.3/mattermost-5.22.3-linux-amd64.tar.gz
+SOURCE_SUM=24ce88ab151c873bcb107a2ff4fdbde7a06ef3d66fa172982ebd931211b2e7e0
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.22.2-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.22.3-linux-amd64.tar.gz

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.22.0/mattermost-5.22.0-linux-amd64.tar.gz
-SOURCE_SUM=40ecb25fca5a1c277f25b60ec97dbdbbf348622dbb75ae6041e2c9d405221650
+SOURCE_URL=https://releases.mattermost.com/5.22.1/mattermost-5.22.1-linux-amd64.tar.gz
+SOURCE_SUM=f4387c393ed70a6674aa30e06ab832d2ef9878110f089e07319a4e314f625acd
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.22.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.22.1-linux-amd64.tar.gz

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     },
     "url": "http://www.mattermost.org/",
     "license": "GPL-3.0-only",
-    "version": "4.6.0-1",
+    "version": "5.22.3~ynh1",
     "maintainer": {
         "name": "pmorinerie",
         "email": "kemenaran@gmail.com"


### PR DESCRIPTION
Hi @kemenaran!

Mattermost v5.22.3 dot release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/kx3yrgpqa7d49fnim6izzitwge). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!