### PR TITLE
Upgrade the sources to Mattermost v5.23

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.22.3/mattermost-5.22.3-linux-amd64.tar.gz
-SOURCE_SUM=24ce88ab151c873bcb107a2ff4fdbde7a06ef3d66fa172982ebd931211b2e7e0
+SOURCE_URL=https://releases.mattermost.com/5.23.0/mattermost-5.23.0-linux-amd64.tar.gz
+SOURCE_SUM=258310291cc99b8029c33023e3466fe8437a00c0370afb6ad7a3b8e5902ad2e8
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.22.3-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.23.0-linux-amd64.tar.gz


### PR DESCRIPTION
Mattermost v5.23 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/acsdgnirsif7zq8xxxciuseh4e). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!