### PR TITLE
Upgrade to Mattermost v5.24.2

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.24.0/mattermost-5.24.0-linux-amd64.tar.gz
-SOURCE_SUM=f539fde8b81228f9b098e03a90988c3599d912d1b95bbe69b9993c2f8030fc10
+SOURCE_URL=https://releases.mattermost.com/5.24.1/mattermost-5.24.1-linux-amd64.tar.gz
+SOURCE_SUM=ff20aea5cb55353cda5a9e2fe8922a0050fbad2a9669879d1f72df018a968891
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.24.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.24.1-linux-amd64.tar.gz

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.24.1/mattermost-5.24.1-linux-amd64.tar.gz
-SOURCE_SUM=ff20aea5cb55353cda5a9e2fe8922a0050fbad2a9669879d1f72df018a968891
+SOURCE_URL=https://releases.mattermost.com/5.24.2/mattermost-5.24.2-linux-amd64.tar.gz
+SOURCE_SUM=cd2ace174ae86cbd5d9564b35a200a21840720bcffebde0bde3ec8b7e810ece5
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.24.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.24.2-linux-amd64.tar.gz

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.23.1/mattermost-5.23.1-linux-amd64.tar.gz
-SOURCE_SUM=406238c445c35ba61f948dc9678b86d67334c171a71438b6f5982664b92d4ba4
+SOURCE_URL=https://releases.mattermost.com/5.24.0/mattermost-5.24.0-linux-amd64.tar.gz
+SOURCE_SUM=f539fde8b81228f9b098e03a90988c3599d912d1b95bbe69b9993c2f8030fc10
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.23.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.24.0-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran!

Mattermost v5.24.2 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/gttetxtypifkxpn6p4wcdx8jxw). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!