### PR TITLE
Propose Upgrading to Mattermost v5.25.0

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.24.2/mattermost-5.24.2-linux-amd64.tar.gz
-SOURCE_SUM=cd2ace174ae86cbd5d9564b35a200a21840720bcffebde0bde3ec8b7e810ece5
+SOURCE_URL=https://releases.mattermost.com/5.25.0/mattermost-5.25.0-linux-amd64.tar.gz
+SOURCE_SUM=f68e24062c9017b111316a0e85e15de26480c6fc8ede54a6531e1f5d5b245723
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.24.2-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.25.0-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.25.0 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/ezrfhro4a3np3eb134n34btozo). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!