### PR TITLE
Propose Upgrading to Mattermost v5.25.2

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.25.0/mattermost-5.25.0-linux-amd64.tar.gz
-SOURCE_SUM=f68e24062c9017b111316a0e85e15de26480c6fc8ede54a6531e1f5d5b245723
+SOURCE_URL=https://releases.mattermost.com/5.25.1/mattermost-5.25.1-linux-amd64.tar.gz
+SOURCE_SUM=2c7fb981bde826bcee87e93b3b78af0f9be6679204d9deb831bb874e6915f151
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.25.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.25.1-linux-amd64.tar.gz

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.25.1/mattermost-5.25.1-linux-amd64.tar.gz
-SOURCE_SUM=2c7fb981bde826bcee87e93b3b78af0f9be6679204d9deb831bb874e6915f151
+SOURCE_URL=https://releases.mattermost.com/5.25.2/mattermost-5.25.2-linux-amd64.tar.gz
+SOURCE_SUM=619a5733aa2f0492b719465b330a8ff1f2c31d03f181f7cec523f8efa421b416
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.25.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.25.2-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.25.2 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/58j3wukxsf8e5y9q7os6twocrh). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!