### PR TITLE
Propose Upgrading to Mattermost v5.26.1

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.25.0/mattermost-5.25.0-linux-amd64.tar.gz
-SOURCE_SUM=f68e24062c9017b111316a0e85e15de26480c6fc8ede54a6531e1f5d5b245723
+SOURCE_URL=https://releases.mattermost.com/5.26.0/mattermost-5.26.0-linux-amd64.tar.gz
+SOURCE_SUM=fecd37b15895793b03ab50aef2a73cc9c43f7dde9c8131ad64180ccf6e8391e7
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.25.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.26.0-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.26.1 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/5aqfjyk4btf38qezm8bqe875oe). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!