### PR TITLE
Propose Upgrading to Mattermost v5.26.2

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.26.0/mattermost-5.26.0-linux-amd64.tar.gz
-SOURCE_SUM=fecd37b15895793b03ab50aef2a73cc9c43f7dde9c8131ad64180ccf6e8391e7
+SOURCE_URL=https://releases.mattermost.com/5.26.2/mattermost-5.26.2-linux-amd64.tar.gz
+SOURCE_SUM=aa671915f684d7daca2fed321ede89dd05c3d377b0beaaca9561b1d7e3c36970
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.26.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.26.2-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.26.2 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/i7w84g5sqjbc8mad99sxs7r4ih). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!