### PR TITLE
Propose Upgrading to Mattermost v5.27.0

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.26.2/mattermost-5.26.2-linux-amd64.tar.gz
-SOURCE_SUM=aa671915f684d7daca2fed321ede89dd05c3d377b0beaaca9561b1d7e3c36970
+SOURCE_URL=https://releases.mattermost.com/5.27.0/mattermost-5.27.0-linux-amd64.tar.gz
+SOURCE_SUM=0c96886174814f1d3ffb9b58376b08a8135b565994d0a9df863c200593e6cfe0
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.26.2-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.27.0-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.27.0 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/98f7qayo1pfkpehrff9r4npnaa). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!