### PR TITLE
Propose Upgrading to Mattermost v5.30.1

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.29.1/mattermost-5.29.1-linux-amd64.tar.gz
-SOURCE_SUM=66175918186cf402213143903230cd8a8b4a96c18d2ee50445f303685accb2c7
+SOURCE_URL=https://releases.mattermost.com/5.30.1/mattermost-5.30.1-linux-amd64.tar.gz
+SOURCE_SUM=14018addf86c040200515cb0141308a6d213f149f8afe425dd171347be516401
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.29.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.30.1-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.30.1 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/zj1nzagydiymim4qxqx8iz1yso). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!