### PR TITLE
Propose Upgrading to Mattermost v5.31.0

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.30.1/mattermost-5.30.1-linux-amd64.tar.gz
-SOURCE_SUM=14018addf86c040200515cb0141308a6d213f149f8afe425dd171347be516401
+SOURCE_URL=https://releases.mattermost.com/5.31.0/mattermost-5.31.0-linux-amd64.tar.gz
+SOURCE_SUM=05e4631a1c755925981838a331addf9575e5ff16f5c4ade2354ef66325f3d06d
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.30.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-5.31.0-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.31.0 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/znffzeb17tbapjsznjsoccraka). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!