### PR TITLE
Fix backward compatibilty for db_name

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -73,6 +73,11 @@ if [ -z "$version" ]; then
   ynh_app_setting_set --app=$app --key=version --value=$version
 fi
 
+if [ -z "$db_name" ]; then
+   db_name="$app"
+   ynh_app_setting_set --app=$app --key=db_name --value=$db_name
+fi
+
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================


### PR DESCRIPTION
c.f. https://forum.yunohost.org/t/mattermost-changer-url-de-base/14289/6

db_name was not saved in the past : https://github.com/YunoHost-Apps/mattermost_ynh/blob/6826e253b40dcf8ec4ebf7aa6b00c91a875f7b14/scripts/install#L98