### PR TITLE
Propose Upgrading to Mattermost v5.31.1 - team edition file

### DIFF
--- a/conf/x86-64.src
+++ b/conf/x86-64.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.31.0/mattermost-team-5.31.0-linux-amd64.tar.gz
-SOURCE_SUM=3c9e862df1166000566772876f38713cf1eb8b64b675bcef3819fb9cc255d7bc
+SOURCE_URL=https://releases.mattermost.com/5.31.1/mattermost-team-5.31.1-linux-amd64.tar.gz
+SOURCE_SUM=83abcef77caf19f2b620e54b2a996b8d6d9f434fcfd8f7402a76cc7183c105b0
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-team-5.31.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-team-5.31.1-linux-amd64.tar.gz


### PR DESCRIPTION
Hi @kemenaran,

Mattermost v5.31.1 release is officially out.

You can find download links with hash numbers [here](https://community.mattermost.com/core/pl/z4asf4i6gtnw8xr38djhox33mw). Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html).

Thanks!