### PR TITLE
conf: update arm and arm64 to mattermost 5.32.1

### DIFF
--- a/conf/arm.src
+++ b/conf/arm.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.31.0/mattermost-v5.31.1-linux-arm.tar.gz
-SOURCE_SUM=00851098feb54afbe457c9991dcf549aa8a4967aecd80bd489865b8fe3afcde02a150b45b1c2b5aec2b02d67543f186be9a245894983270f521e18e464d947d9
+SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.32.1/mattermost-v5.32.1-linux-arm.tar.gz
+SOURCE_SUM=0dccb34687c755fd2f7eed7d53fcee451500a463253e376233c1c86dd37518689d79f2ec2e20d5c21954331e00220ec5bb74e23dcc0db2b004c68ba0402a3f61
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-v5.31.1-linux-arm.tar.gz
+SOURCE_FILENAME=mattermost-v5.32.1-linux-arm.tar.gz

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.31.0/mattermost-v5.31.1-linux-arm64.tar.gz
-SOURCE_SUM=a7e6aa890b897155eee60aa4ce2b874bc601c9a1402cc4796f16697374266c9c7d855b182b5251ba14953a7b2701324b7253f96b6afd3cf16a314cbd77263017
+SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.32.1/mattermost-v5.32.1-linux-arm64.tar.gz
+SOURCE_SUM=83ded96774f3d3b178959f736f64f458d097a738f89e81d992b908173249f2745559caab799fc701ba66efd8e58bca389fbde9f612a9f61e515c11a9726d6910
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-v5.31.1-linux-arm64.tar.gz
+SOURCE_FILENAME=mattermost-v5.32.1-linux-arm64.tar.gz


### PR DESCRIPTION
When releasing the 5.32.1 version, we forgot to update the arm builds.

Fix #222