### PR TITLE
Update Mattermost to 5.34.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 ## Overview
 Mattermost is a self-hosted, open source instant messaging and service software. It's designed as an internal chat for organizations and businesses, and it's touted as an alternative to Slack.
 
-**Shipped version:** 5.33.2
+**Shipped version:** <span class="version">5.34.2</span>
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -11,7 +11,7 @@ Si vous n'avez pas YunoHost, consultez [le guide](https://yunohost.org/#/install
 ## Vue d'ensemble
 Mattermost est un logiciel et un service de messagerie instantanée libre auto-hébergeable. Il est conçu comme un chat interne pour les organisations et les entreprises, et il est présenté comme une alternative à Slack.
 
-**Version incluse :** 5.33.2
+**Version incluse :** <span class="version">5.34.2</span>
 
 ## Captures d'écran
 

--- a/conf/arm.src
+++ b/conf/arm.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.33.2/mattermost-v5.33.2-linux-arm.tar.gz
-SOURCE_SUM=4eb2d69da019979c9792435e175a12b4afb19fe66e70747039d247ca4f0769a87b1b1951a90a43edd021a898dee00946cbeac9ce213e670aeb5fce3203fa4303
+SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.34.2/mattermost-v5.34.2-linux-arm.tar.gz
+SOURCE_SUM=98805b54f0f5403fbee943d2a338a781813392ac7789f3f14ed688833d5578a2000e1af20d245ef75e6beb5ae1f129eda9bd2484e63505653a80b8c97d3d3b0b
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-v5.33.2-linux-arm.tar.gz
+SOURCE_FILENAME=mattermost-v5.34.2-linux-arm.tar.gz

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.33.2/mattermost-v5.33.2-linux-arm64.tar.gz
-SOURCE_SUM=b07ef96872348a481a62fd1ae5c91db8de83b9a03a5281f6b21f75b6c624694f8f53393fb3fa77f2a0d78ad7313a4536ad88ae122cb2957d419ec98f111430c8
+SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.34.2/mattermost-v5.34.2-linux-arm64.tar.gz
+SOURCE_SUM=345c1e3aecd75abdc1b734fc21802698b5ff2b00a9eded47b3ad985706a6352a924e2aa0e1e638119ade09bd4c1689ae18122aba496a45430734b5097c51adc9
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-v5.33.2-linux-arm64.tar.gz
+SOURCE_FILENAME=mattermost-v5.34.2-linux-arm64.tar.gz

--- a/conf/enterprise.src
+++ b/conf/enterprise.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.33.2/mattermost-5.33.2-linux-amd64.tar.gz
-SOURCE_SUM=36faac7bdf70044beed46e7cc9af755b50ac6c1b6531377be9a7a3edcd65191f
+SOURCE_URL=https://releases.mattermost.com/5.34.2/mattermost-enterprise-5.34.2-linux-amd64.tar.gz
+SOURCE_SUM=15111484bd543cc895d91bc74fa500bb23e1bc614526c38acd2c2aaaf5435da5
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-5.33.2-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-enterprise-5.34.2-linux-amd64.tar.gz

--- a/conf/x86-64.src
+++ b/conf/x86-64.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.33.2/mattermost-team-5.33.2-linux-amd64.tar.gz
-SOURCE_SUM=d9498dc7b474f80029830cfa1f55221d76c0dd603e38273f7019a97830eba2f5
+SOURCE_URL=https://releases.mattermost.com/5.34.2/mattermost-team-5.34.2-linux-amd64.tar.gz
+SOURCE_SUM=7346b4ac5132c69c677b4f738a18c6d0969ad4ae466f29d6f02b361878801ec6
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-team-5.33.2-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-team-5.34.2-linux-amd64.tar.gz


### PR DESCRIPTION
NB: 5.34.2 is out, but not packaged for ARM yet. Let's wait a few days until 5.34.2 is ready for all platforms (looks like it fixes a nasty bug).