### PR TITLE
Upgrade to Mattermost 5.38.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Open source collaboration platform built for developers
 
-**Shipped version:** 5.37.1~ynh1
+**Shipped version:** 5.38.0~ynh1
 
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Open source collaboration platform built for developers
 
-**Shipped version:** 5.38.0~ynh1
+**Shipped version:** 5.38.1~ynh1
 
 
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -13,7 +13,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Plateforme de collaboration open source conçue pour les développeurs
 
-**Version incluse :** 5.38.0~ynh1
+**Version incluse :** 5.38.1~ynh1
 
 
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -13,7 +13,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Plateforme de collaboration open source conçue pour les développeurs
 
-**Version incluse :** 5.37.1~ynh1
+**Version incluse :** 5.38.0~ynh1
 
 
 

--- a/conf/arm.src
+++ b/conf/arm.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.38.0/mattermost-v5.38.0-linux-arm.tar.gz
-SOURCE_SUM=7d312996ad36976316b3ff26a9a7293abaafbcd763d37ac0796b205bf18415e4f4cd698ec22e53b9607610363a25363843786c5683b33eaee543c6164b71c405
+SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.38.1/mattermost-v5.38.1-linux-arm.tar.gz
+SOURCE_SUM=a5aef5f4a345d2380fb356262e0bd3e2e933940acfb1df7e815f8e7818651a2eb18361bf2f94314cc961055cfca4f28dcc93f6553265aafccf8a4dd0195464b3
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-v5.38.0-linux-arm.tar.gz
+SOURCE_FILENAME=mattermost-v5.38.1-linux-arm.tar.gz

--- a/conf/arm.src
+++ b/conf/arm.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.37.1/mattermost-v5.37.1-linux-arm.tar.gz
-SOURCE_SUM=1b9ade4ded5856b050f03edca364505185f6d91a3378ccd3ec0c95a48bbe7215d6492cd822240a60534625ca043574b7eb1687091c813ae53ad64ee49cf4f8d8
+SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.38.0/mattermost-v5.38.0-linux-arm.tar.gz
+SOURCE_SUM=7d312996ad36976316b3ff26a9a7293abaafbcd763d37ac0796b205bf18415e4f4cd698ec22e53b9607610363a25363843786c5683b33eaee543c6164b71c405
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-v5.37.1-linux-arm.tar.gz
+SOURCE_FILENAME=mattermost-v5.38.0-linux-arm.tar.gz

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.38.0/mattermost-v5.38.0-linux-arm64.tar.gz
-SOURCE_SUM=28f1f150f27828487bd1501164896e7dd347ce97f49fa9f4e7d74fd5a97b6ce83339a26e8c8bec5893fae0001547b3edb579c9ad02c7caaadd05fc4e2cc20f1a
+SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.38.1/mattermost-v5.38.1-linux-arm64.tar.gz
+SOURCE_SUM=bf809a26dceb2ace0d54380200c6edfb807cf3db90ad3448a64724fcf14b87260fc8d20a1e5a37361d7603aa3642159c4674b3304061d5f4edbbfed7bc678427
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-v5.38.0-linux-arm64.tar.gz
+SOURCE_FILENAME=mattermost-v5.38.1-linux-arm64.tar.gz

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.37.1/mattermost-v5.37.1-linux-arm64.tar.gz
-SOURCE_SUM=d4d1e36c79240d7d0f361c042ac3ddf019c6d624ba1f97f5cbb930938a05e3653b4246b5a36bcc51c29cb190e49c67b88d3293fcfd16ea513ad8a0359dee4467
+SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v5.38.0/mattermost-v5.38.0-linux-arm64.tar.gz
+SOURCE_SUM=28f1f150f27828487bd1501164896e7dd347ce97f49fa9f4e7d74fd5a97b6ce83339a26e8c8bec5893fae0001547b3edb579c9ad02c7caaadd05fc4e2cc20f1a
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-v5.37.1-linux-arm64.tar.gz
+SOURCE_FILENAME=mattermost-v5.38.0-linux-arm64.tar.gz

--- a/conf/enterprise.src
+++ b/conf/enterprise.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.37.1/mattermost-enterprise-5.37.1-linux-amd64.tar.gz
-SOURCE_SUM=acd0b2ead09f289a7920ea9a37fde76155f599775102016ad3463cf1bcf54405
+SOURCE_URL=https://releases.mattermost.com/5.38.0/mattermost-enterprise-5.38.0-linux-amd64.tar.gz
+SOURCE_SUM=af97528f148ce4ff6e93547c4c1385c0bbb3f10bce917fe671c2eeeb73ce934a
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-enterprise-5.37.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-enterprise-5.38.0-linux-amd64.tar.gz

--- a/conf/enterprise.src
+++ b/conf/enterprise.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.38.0/mattermost-enterprise-5.38.0-linux-amd64.tar.gz
-SOURCE_SUM=af97528f148ce4ff6e93547c4c1385c0bbb3f10bce917fe671c2eeeb73ce934a
+SOURCE_URL=https://releases.mattermost.com/5.38.1/mattermost-enterprise-5.38.1-linux-amd64.tar.gz
+SOURCE_SUM=c8f72ef5a219b7663662987418c581635863def1865b07da7a3033e26375c693
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-enterprise-5.38.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-enterprise-5.38.1-linux-amd64.tar.gz

--- a/conf/x86-64.src
+++ b/conf/x86-64.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.38.0/mattermost-team-5.38.0-linux-amd64.tar.gz
-SOURCE_SUM=c38e3ce6078b346dab960203a9bbfa1adc918d0288d3678cd83f5c4b1106ca16
+SOURCE_URL=https://releases.mattermost.com/5.38.1/mattermost-team-5.38.1-linux-amd64.tar.gz
+SOURCE_SUM=9c3613d8f735a13a55451b46b1ce222c619890f2ac9bef1cf48b22d442b932ce
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-team-5.38.0-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-team-5.38.1-linux-amd64.tar.gz

--- a/conf/x86-64.src
+++ b/conf/x86-64.src
@@ -1,6 +1,6 @@
-SOURCE_URL=https://releases.mattermost.com/5.37.1/mattermost-team-5.37.1-linux-amd64.tar.gz
-SOURCE_SUM=a70e829180ed5d3b3e688f1d264bafae93a7ecf80970e16b673c5473beaf137f
+SOURCE_URL=https://releases.mattermost.com/5.38.0/mattermost-team-5.38.0-linux-amd64.tar.gz
+SOURCE_SUM=c38e3ce6078b346dab960203a9bbfa1adc918d0288d3678cd83f5c4b1106ca16
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=mattermost-team-5.37.1-linux-amd64.tar.gz
+SOURCE_FILENAME=mattermost-team-5.38.0-linux-amd64.tar.gz

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Open source collaboration platform built for developers",
         "fr": "Plateforme de collaboration open source conçue pour les développeurs"
     },
-    "version": "5.37.1~ynh1",
+    "version": "5.38.0~ynh1",
     "url": "http://www.mattermost.org/",
     "upstream": {
         "license": "GPL-3.0-only",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Open source collaboration platform built for developers",
         "fr": "Plateforme de collaboration open source conçue pour les développeurs"
     },
-    "version": "5.38.0~ynh1",
+    "version": "5.38.1~ynh1",
     "url": "http://www.mattermost.org/",
     "upstream": {
         "license": "GPL-3.0-only",

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -194,10 +194,10 @@ yunohost service add $app --description="Collaboration platform built for develo
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=2
 
-# A lengthy database migration runs when upgrading from a version < 5.35.
-if dpkg --compare-versions "$previous_upstream_version" lt "5.35.0"
+# A lengthy database migration runs when upgrading from a version < 5.38.
+if dpkg --compare-versions "$previous_upstream_version" lt "5.38.0"
 then
-  ynh_print_warn --message="A database migration will now run. This may take a while..."
+  ynh_print_warn --message="Lengthy database migrations will now run. This may take a while..."
 fi
 
 # Start a systemd service


### PR DESCRIPTION
➡️ Mattermost's [changlog for 5.38.1](https://docs.mattermost.com/install/self-managed-changelog.html).

Note that this release contains two potentially lengthy database migrations. The upgrade script will notice users before migrating the data.