### PR TITLE
Migrate from bin/mattermost to bin/mmctl

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -83,7 +83,7 @@
     "EnableSVGs": false,
     "EnableLatex": false,
     "EnableAPIChannelDeletion": false,
-    "EnableLocalMode": false,
+    "EnableLocalMode": true,
     "LocalModeSocketLocation": "/var/tmp/mattermost_local.socket",
     "EnableAWSMetering": false,
     "SplitKey": "",

--- a/scripts/install
+++ b/scripts/install
@@ -164,19 +164,6 @@ ynh_script_progression --message="Configuring a systemd service..." --weight=2
 ynh_add_systemd_config
 
 #=================================================
-# CREATE ADMIN AND FIRST TEAM
-#=================================================
-
-team_name=$(echo "$team_display_name" | iconv -f utf8 -t ascii//TRANSLIT//IGNORE | sed -e 's/[^[:alnum:]]/-/g' | tr -s '-' | tr A-Z a-z)
-
-pushd "$final_path"
-	ynh_exec_warn_less ynh_exec_as $app bin/mattermost user create --username "$admin" --email "$email" --password "$password" --locale "$language" --system_admin
-	ynh_exec_warn_less ynh_exec_as $app bin/mattermost user verify "$admin"
-	ynh_exec_warn_less ynh_exec_as $app bin/mattermost team create --name "$team_name" --display_name "$team_display_name" --email "$email"
-	ynh_exec_warn_less ynh_exec_as $app bin/mattermost team add "$team_name" "$admin"
-popd
-
-#=================================================
 # INTEGRATE SERVICE IN YUNOHOST
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
@@ -190,6 +177,24 @@ ynh_script_progression --message="Starting a systemd service..." --weight=2
 
 # Start a systemd service
 ynh_systemd_action --service_name=$app --action=start --log_path=systemd --line_match="Started Mattermost"
+
+#=================================================
+# CREATE ADMIN AND FIRST TEAM
+#=================================================
+ynh_script_progression --message="Create the first administrator and team..." --weight=1
+
+team_name=$(echo "$team_display_name" | iconv -f utf8 -t ascii//TRANSLIT//IGNORE | sed -e 's/[^[:alnum:]]/-/g' | tr -s '-' | tr A-Z a-z)
+
+pushd "$final_path"
+  ynh_exec_warn_less ynh_exec_as $app bin/mmctl user create --local --username "$admin" --email "$email" --password "$password" --locale "$language" --system_admin
+  ynh_exec_warn_less ynh_exec_as $app bin/mmctl user verify --local "$admin"
+  ynh_exec_warn_less ynh_exec_as $app bin/mmctl team create --local --name "$team_name" --display_name "$team_display_name" --email "$email"
+  ynh_exec_warn_less ynh_exec_as $app bin/mmctl team add --local "$team_name" "$admin"
+popd
+
+# Now that the first user is created, disable mmctl passwordless access
+ynh_replace_string '"EnableLocalMode": true' '"EnableLocalMode": false' "$final_path/config/config.json"
+ynh_systemd_action --service_name=$app --action=restart --log_path=systemd --line_match="Started Mattermost"
 
 #=================================================
 # SETUP SSOWAT


### PR DESCRIPTION
`mmctl` is supposed to authenticate as one of the admin users. But since
this is the first user we're creating, there are no admin yet.

So in order to create the first user, we:

1. enable mmctl's "local mode", which connects to the Mattermost server
   through a socket (rather than through the authenticated API), 
2. create the first user and team,
3. disable the "local mode".
