### PR TITLE
Fix 6.0 install

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -84,7 +84,7 @@
     "EnableLatex": false,
     "EnableAPIChannelDeletion": false,
     "EnableLocalMode": true,
-    "LocalModeSocketLocation": "/var/tmp/mattermost_local.socket",
+    "LocalModeSocketLocation": "__LOCAL_SOCKET_PATH__",
     "EnableAWSMetering": false,
     "SplitKey": "",
     "FeatureFlagSyncIntervalSeconds": 30,

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -11,6 +11,7 @@ TimeoutStartSec=3600
 Restart=always
 RestartSec=10
 WorkingDirectory=__FINALPATH__
+RuntimeDirectory=__APP__
 User=__APP__
 Group=__APP__
 LimitNOFILE=49152

--- a/scripts/install
+++ b/scripts/install
@@ -144,6 +144,7 @@ ynh_script_progression --message="Modifying a config file..." --weight=3
 
 smtp_user_pwd=$(ynh_string_random --length=24)
 url=https://$domain$path_url
+local_socket_path="/var/run/${app}/mattermost_local.socket"
 
 ynh_add_config --template="../conf/config.json" --destination="$final_path/config/config.json"
 
@@ -186,10 +187,13 @@ ynh_script_progression --message="Create the first administrator and team..." --
 team_name=$(echo "$team_display_name" | iconv -f utf8 -t ascii//TRANSLIT//IGNORE | sed -e 's/[^[:alnum:]]/-/g' | tr -s '-' | tr A-Z a-z)
 
 pushd "$final_path"
-  ynh_exec_warn_less ynh_exec_as $app bin/mmctl user create --local --username "$admin" --email "$email" --password "$password" --locale "$language" --system-admin
-  ynh_exec_warn_less ynh_exec_as $app bin/mmctl user verify --local "$admin"
-  ynh_exec_warn_less ynh_exec_as $app bin/mmctl team create --local --name "$team_name" --display_name "$team_display_name" --email "$email"
-  ynh_exec_warn_less ynh_exec_as $app bin/mmctl team add --local "$team_name" "$admin"
+  export MMCTL_LOCAL=true
+  export MMCTL_LOCAL_SOCKET_PATH="$local_socket_path"
+
+  ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl user create --username "$admin" --email "$email" --password "$password" --locale "$language" --system-admin
+  ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl user verify "$admin"
+  ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl team create --name "$team_name" --display_name "$team_display_name" --email "$email"
+  ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl team add "$team_name" "$admin"
 popd
 
 # Now that the first user is created, disable mmctl passwordless access

--- a/scripts/install
+++ b/scripts/install
@@ -186,7 +186,7 @@ ynh_script_progression --message="Create the first administrator and team..." --
 team_name=$(echo "$team_display_name" | iconv -f utf8 -t ascii//TRANSLIT//IGNORE | sed -e 's/[^[:alnum:]]/-/g' | tr -s '-' | tr A-Z a-z)
 
 pushd "$final_path"
-  ynh_exec_warn_less ynh_exec_as $app bin/mmctl user create --local --username "$admin" --email "$email" --password "$password" --locale "$language" --system_admin
+  ynh_exec_warn_less ynh_exec_as $app bin/mmctl user create --local --username "$admin" --email "$email" --password "$password" --locale "$language" --system-admin
   ynh_exec_warn_less ynh_exec_as $app bin/mmctl user verify --local "$admin"
   ynh_exec_warn_less ynh_exec_as $app bin/mmctl team create --local --name "$team_name" --display_name "$team_display_name" --email "$email"
   ynh_exec_warn_less ynh_exec_as $app bin/mmctl team add --local "$team_name" "$admin"

--- a/scripts/install
+++ b/scripts/install
@@ -190,8 +190,7 @@ pushd "$final_path"
   export MMCTL_LOCAL=true
   export MMCTL_LOCAL_SOCKET_PATH="$local_socket_path"
 
-  ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl user create --username "$admin" --email "$email" --password "$password" --locale "$language" --system-admin
-  ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl user verify "$admin"
+  ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl user create --username "$admin" --email "$email" --password "$password" --locale "$language" --email-verified --system-admin
   ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl team create --name "$team_name" --display_name "$team_display_name" --email "$email"
   ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl team add "$team_name" "$admin"
 popd

--- a/scripts/install
+++ b/scripts/install
@@ -192,7 +192,7 @@ pushd "$final_path"
 
   ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl user create --username "$admin" --email "$email" --password "$password" --locale "$language" --email-verified --system-admin
   ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl team create --name "$team_name" --display_name "$team_display_name" --email "$email"
-  ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl team add "$team_name" "$admin"
+  ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl team users add "$team_name" "$admin"
 popd
 
 # Now that the first user is created, disable mmctl passwordless access


### PR DESCRIPTION
A 6.0 install as a second instance on a Yunohost server fails when creating the admin user, with the following error:

> 191443 DEBUG Error: socket file "/var/tmp/mattermost_local.socket" doesn't exists, please check the server configuration for local mode

This attempts to fix the issue by putting the socket in /var/run instead, which should be writable by anyone. 