### PR TITLE
Skip creating user and team if mmctl is not available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To explore the benefits of Mattermost’s enterprise features, you can replace t
 - Multiple languages including U.S. English, Australian English, Bulgarian, Chinese (Simplified and Traditional), Dutch, French, German, Hungarian, Italian, Japanese, Korean, Polish, Brazilian Portuguese, Romanian, Russian, Turkish, Spanish, Swedish, and Ukrainian
 
 
-**Shipped version:** 6.0.2~ynh1
+**Shipped version:** 6.0.2~ynh2
 
 
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -33,7 +33,7 @@ Pour explorer les avantages des fonctionnalités d'entreprise de Mattermost, vou
 - Plusieurs langues dont l'anglais américain, l'anglais australien, le bulgare, le chinois (simplifié et traditionnel), le néerlandais, le français, l'allemand, le hongrois, l'italien, le japonais, le coréen, le polonais, le portugais brésilien, le roumain, le russe, le turc, l'espagnol, le suédois et l'ukrainien 
 
 
-**Version incluse :** 6.0.2~ynh1
+**Version incluse :** 6.0.2~ynh2
 
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Open source collaboration platform built for developers",
         "fr": "Plateforme de collaboration open source conçue pour les développeurs"
     },
-    "version": "6.0.2~ynh1",
+    "version": "6.0.2~ynh2",
     "url": "http://www.mattermost.org/",
     "upstream": {
         "license": "GPL-3.0-only",

--- a/scripts/install
+++ b/scripts/install
@@ -187,14 +187,17 @@ ynh_script_progression --message="Create the first administrator and team..." --
 team_name=$(echo "$team_display_name" | iconv -f utf8 -t ascii//TRANSLIT//IGNORE | sed -e 's/[^[:alnum:]]/-/g' | tr -s '-' | tr A-Z a-z)
 bin_mmctl="$final_path/bin/mmctl"
 
-export MMCTL_LOCAL=true
-export MMCTL_LOCAL_SOCKET_PATH="$local_socket_path"
+# mmctl is not packaged with ARM versions yet
+if [[ -f $"bin_mmctl" ]]; then
+  export MMCTL_LOCAL=true
+  export MMCTL_LOCAL_SOCKET_PATH="$local_socket_path"
 
-ynh_exec_warn_less sudo --preserve-env -u $app "$bin_mmctl" user create --username "$admin" --email "$email" --password "$password" --locale "$language" --email-verified --system-admin
-ynh_exec_warn_less sudo --preserve-env -u $app "$bin_mmctl" team create --name "$team_name" --display_name "$team_display_name" --email "$email"
-ynh_exec_warn_less sudo --preserve-env -u $app "$bin_mmctl" team users add "$team_name" "$admin"
+  ynh_exec_warn_less sudo --preserve-env -u $app "$bin_mmctl" user create --username "$admin" --email "$email" --password "$password" --locale "$language" --email-verified --system-admin
+  ynh_exec_warn_less sudo --preserve-env -u $app "$bin_mmctl" team create --name "$team_name" --display_name "$team_display_name" --email "$email"
+  ynh_exec_warn_less sudo --preserve-env -u $app "$bin_mmctl" team users add "$team_name" "$admin"
+fi
 
-# Now that the first user is created, disable mmctl passwordless access
+# Disable mmctl passwordless access
 ynh_replace_string '"EnableLocalMode": true' '"EnableLocalMode": false' "$final_path/config/config.json"
 ynh_systemd_action --service_name=$app --action=restart --log_path=systemd --line_match="Started Mattermost"
 

--- a/scripts/install
+++ b/scripts/install
@@ -185,15 +185,14 @@ ynh_systemd_action --service_name=$app --action=start --log_path=systemd --line_
 ynh_script_progression --message="Create the first administrator and team..." --weight=1
 
 team_name=$(echo "$team_display_name" | iconv -f utf8 -t ascii//TRANSLIT//IGNORE | sed -e 's/[^[:alnum:]]/-/g' | tr -s '-' | tr A-Z a-z)
+bin_mmctl="$final_path/bin/mmctl"
 
-pushd "$final_path"
-  export MMCTL_LOCAL=true
-  export MMCTL_LOCAL_SOCKET_PATH="$local_socket_path"
+export MMCTL_LOCAL=true
+export MMCTL_LOCAL_SOCKET_PATH="$local_socket_path"
 
-  ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl user create --username "$admin" --email "$email" --password "$password" --locale "$language" --email-verified --system-admin
-  ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl team create --name "$team_name" --display_name "$team_display_name" --email "$email"
-  ynh_exec_warn_less sudo --preserve-env -u $app bin/mmctl team users add "$team_name" "$admin"
-popd
+ynh_exec_warn_less sudo --preserve-env -u $app "$bin_mmctl" user create --username "$admin" --email "$email" --password "$password" --locale "$language" --email-verified --system-admin
+ynh_exec_warn_less sudo --preserve-env -u $app "$bin_mmctl" team create --name "$team_name" --display_name "$team_display_name" --email "$email"
+ynh_exec_warn_less sudo --preserve-env -u $app "$bin_mmctl" team users add "$team_name" "$admin"
 
 # Now that the first user is created, disable mmctl passwordless access
 ynh_replace_string '"EnableLocalMode": true' '"EnableLocalMode": false' "$final_path/config/config.json"


### PR DESCRIPTION
Mmctl is not packaged with ARM builds yet (see https://github.com/SmartHoneybee/ubiquitous-memory/pull/136)

Until the ARM build is updated, allow the install to continue nonetheless by skipping the first user and team creation if mmctl is not available.

Refs #306; fix #304

