### PR TITLE
Fix arm and arm64 releases shasum

### DIFF
--- a/conf/arm.src
+++ b/conf/arm.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v6.0.2/mattermost-v6.0.2-linux-arm.tar.gz
-SOURCE_SUM=465788c52826143f4c5e3198dce08088f61d5511431b2d5272a63ee618757e04
+SOURCE_SUM=80554cba9854df81454ba41db83c391d49003aa9ded736dfcfb53de88789c0c4
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v6.0.2/mattermost-v6.0.2-linux-arm64.tar.gz
-SOURCE_SUM=53debd6dda971aac8a199f0a56ccbabc324a5bcafaa4a3038425bbcdd766e599
+SOURCE_SUM=bfa9b7ee30e7f4e654358f628bb75011d0835cdcab3fd17a8bd18e227bc8ff25
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true


### PR DESCRIPTION
The upstream release was republished (with an updated version that includes mmctl), so the shasum changed too.