### PR TITLE
6.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To explore the benefits of Mattermost’s enterprise features, you can replace t
 - Multiple languages including U.S. English, Australian English, Bulgarian, Chinese (Simplified and Traditional), Dutch, French, German, Hungarian, Italian, Japanese, Korean, Polish, Brazilian Portuguese, Romanian, Russian, Turkish, Spanish, Swedish, and Ukrainian
 
 
-**Shipped version:** 6.0.2~ynh2
+**Shipped version:** 6.1.0~ynh1
 
 
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -33,7 +33,7 @@ Pour explorer les avantages des fonctionnalités d'entreprise de Mattermost, vou
 - Plusieurs langues dont l'anglais américain, l'anglais australien, le bulgare, le chinois (simplifié et traditionnel), le néerlandais, le français, l'allemand, le hongrois, l'italien, le japonais, le coréen, le polonais, le portugais brésilien, le roumain, le russe, le turc, l'espagnol, le suédois et l'ukrainien 
 
 
-**Version incluse :** 6.0.2~ynh2
+**Version incluse :** 6.1.0~ynh1
 
 
 

--- a/bump-mattermost.rb
+++ b/bump-mattermost.rb
@@ -61,10 +61,9 @@ module Mattermost
     def retrieve_smart_honeybee_release_data
       @url = "https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v#{version}/mattermost-v#{version}-linux-#{variant}.tar.gz"
 
-      sum_url = "#{url}.sha512sum"
-      URI.open(sum_url) do |sum_file|
-        @sum = sum_file.read.lines.first.split(' ').first
-      end
+      puts "Downloading release #{version}-#{variant} for computing checksum…"
+      release_file = URI.parse(@url).read
+      @sum = Digest::SHA256.hexdigest(release_file)
     end
   end
 end
@@ -79,7 +78,6 @@ module Yunohost
       src = File.read(@path)
       replace_src_setting!(src, 'SOURCE_URL', release.url)
       replace_src_setting!(src, 'SOURCE_SUM', release.sum)
-      replace_src_setting!(src, 'SOURCE_FILENAME', File.basename(URI.parse(release.url).path))
       File.write(@path, src)
     end
 

--- a/conf/arm.src
+++ b/conf/arm.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v6.0.2/mattermost-v6.0.2-linux-arm.tar.gz
-SOURCE_SUM=80554cba9854df81454ba41db83c391d49003aa9ded736dfcfb53de88789c0c4
+SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v6.1.0/mattermost-v6.1.0-linux-arm.tar.gz
+SOURCE_SUM=9b81f4fa74ab69f636beba0dd9ee07bef86f9e6320caed394f1878b433818ae8
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v6.0.2/mattermost-v6.0.2-linux-arm64.tar.gz
-SOURCE_SUM=bfa9b7ee30e7f4e654358f628bb75011d0835cdcab3fd17a8bd18e227bc8ff25
+SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v6.1.0/mattermost-v6.1.0-linux-arm64.tar.gz
+SOURCE_SUM=4fa5e55699749bb524eb1e9b4b918e862c5eaf55678f4590cdeb9b5fa9e35411
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/enterprise.src
+++ b/conf/enterprise.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://releases.mattermost.com/6.0.2/mattermost-enterprise-6.0.2-linux-amd64.tar.gz
-SOURCE_SUM=4580a435a350c9401d50972e720a47e2551eba889a51b976991c6b906a2ac1fd
+SOURCE_URL=https://releases.mattermost.com/6.1.0/mattermost-enterprise-6.1.0-linux-amd64.tar.gz
+SOURCE_SUM=304a46c1abf984b97d6adaf74b8ab4324df68178dcd95cdf721ad02756c7e14d
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/x86-64.src
+++ b/conf/x86-64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://releases.mattermost.com/6.0.2/mattermost-team-6.0.2-linux-amd64.tar.gz
-SOURCE_SUM=56a2148e8cac5c40ac700fed4cd52c875c512fa0dce5e54f1414af7513f0cb8e
+SOURCE_URL=https://releases.mattermost.com/6.1.0/mattermost-team-6.1.0-linux-amd64.tar.gz
+SOURCE_SUM=8f7ed5402109c7b8c6eb30c654148c8fea56a4c81650d282d3c15443fbcb8410
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Open source collaboration platform built for developers",
         "fr": "Plateforme de collaboration open source conçue pour les développeurs"
     },
-    "version": "6.0.2~ynh2",
+    "version": "6.1.0~ynh1",
     "url": "http://www.mattermost.org/",
     "upstream": {
         "license": "GPL-3.0-only",


### PR DESCRIPTION
Update to Mattermost 6.1.0 (fix #311)

Changelog: https://docs.mattermost.com/administration/changelog.html

NB: the third-party ARM builds include mmctl, but are packaged without the pre-packaged plugins. (See https://github.com/SmartHoneybee/ubiquitous-memory/pull/137)