### PR TITLE
config: allow connections to the Plugins marketplace

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -36,7 +36,7 @@
     "EnableOpenTracing": false,
     "EnableSecurityFixAlert": true,
     "EnableInsecureOutgoingConnections": false,
-    "AllowedUntrustedInternalConnections": "",
+    "AllowedUntrustedInternalConnections": "api.integrations.mattermost.com",
     "EnableMultifactorAuthentication": false,
     "EnforceMultifactorAuthentication": false,
     "EnableUserAccessTokens": false,


### PR DESCRIPTION
Otherwise the connections to the available plugins lists on the default Marketplace are blocked, which is a bad user experience.

Fixes the Marketplace not being able to be displayed.