### PR TITLE
systemd.service for PostgreSQL

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Mattermost
 After=network.target
-After=mysql.service
-Requires=mysql.service
+After=postgresql.service
+Requires=postgresql.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
## Problem

Propose an install script with PostgreSQL to avoid potential issues with MariaDB (see https://github.com/YunoHost-Apps/mattermost_ynh/issues/367)

## Solution

Question: in https://docs.mattermost.com/install/install-debian.html#install-postgresql-database-server, I see `BindsTo=postgresql.service` while in the original file here I find `Requires=mysql.service`. I don't know which one makes sense, so I keep the orinigal Yunohost version (Requires)

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)