### PR TITLE
Revert "Testing (Upgrade to Mattermost 7.3)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To explore the benefits of Mattermost’s enterprise features, you can replace t
 - Multiple languages including U.S. English, Australian English, Bulgarian, Chinese (Simplified and Traditional), Dutch, French, German, Hungarian, Italian, Japanese, Korean, Polish, Brazilian Portuguese, Romanian, Russian, Turkish, Spanish, Swedish, and Ukrainian
 
 
-**Shipped version:** 7.3.0~ynh1
+**Shipped version:** 7.2.0~ynh1
 
 
 ## Screenshots

--- a/README_fr.md
+++ b/README_fr.md
@@ -37,7 +37,7 @@ Pour explorer les avantages des fonctionnalités d'entreprise de Mattermost, vou
 - Plusieurs langues dont l'anglais américain, l'anglais australien, le bulgare, le chinois (simplifié et traditionnel), le néerlandais, le français, l'allemand, le hongrois, l'italien, le japonais, le coréen, le polonais, le portugais brésilien, le roumain, le russe, le turc, l'espagnol, le suédois et l'ukrainien 
 
 
-**Version incluse :** 7.3.0~ynh1
+**Version incluse :** 7.2.0~ynh1
 
 
 ## Captures d'écran

--- a/conf/amd64.src
+++ b/conf/amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://releases.mattermost.com/7.3.0/mattermost-team-7.3.0-linux-amd64.tar.gz
-SOURCE_SUM=47602e67b457a4871fd459f32a67f44e3353e4152989157eced2ad3bff5f634b
+SOURCE_URL=https://releases.mattermost.com/7.2.0/mattermost-team-7.2.0-linux-amd64.tar.gz
+SOURCE_SUM=185eecbcee8bdfc10f9c99f04a294912269701da86a6217eb48cc761207fca80
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v7.3.0/mattermost-v7.3.0-linux-arm64.tar.gz
-SOURCE_SUM=9ea92cee34bf8209ce8e9a1fb186541a4784dd6ee63c93f6d9d0e3af078cd2aa
+SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v7.2.0/mattermost-v7.2.0-linux-arm64.tar.gz
+SOURCE_SUM=d5ff399f4e025a77c8d009ed0c64d029ecba3a3d5ab8271fca6d5aabf25d97d8
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/armhf.src
+++ b/conf/armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v7.3.0/mattermost-v7.3.0-linux-arm.tar.gz
-SOURCE_SUM=742314c0e9cb2f26d444c658c72794bd506a00c79066f7d908e9058ed48cdaa4
+SOURCE_URL=https://github.com/SmartHoneybee/ubiquitous-memory/releases/download/v7.2.0/mattermost-v7.2.0-linux-arm.tar.gz
+SOURCE_SUM=f5a1697242c6064276107085dabc80db442365244bc9ddc8f19010b4522591dd
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/config.json
+++ b/conf/config.json
@@ -210,8 +210,7 @@
     "AmazonS3SSL": true,
     "AmazonS3SignV2": false,
     "AmazonS3SSE": false,
-    "AmazonS3Trace": false,
-    "AmazonS3RequestTimeoutMilliseconds": 30000
+    "AmazonS3Trace": false
   },
   "EmailSettings": {
     "EnableSignUpWithEmail": true,
@@ -602,9 +601,10 @@
     "GraphQL": false,
     "InsightsEnabled": true,
     "CommandPalette": false,
+    "PostForwarding": true,
     "AdvancedTextEditor": true,
     "BoardsProduct": false,
-    "PlanUpgradeButtonText": "upgrade"
+    "PlanUpgradeButtonText": "Upgrade"
   },
   "ImportSettings": {
     "Directory": "./import",

--- a/conf/enterprise.src
+++ b/conf/enterprise.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://releases.mattermost.com/7.3.0/mattermost-enterprise-7.3.0-linux-amd64.tar.gz
-SOURCE_SUM=7c88dab1a68010c3cb6b1a3ce8c7c04aa4e9ff45b3cd30ca24008a5ae59bcbf0
+SOURCE_URL=https://releases.mattermost.com/7.2.0/mattermost-enterprise-7.2.0-linux-amd64.tar.gz
+SOURCE_SUM=1404ed3bac456bf6cac32c3284a105660ae57b440f29923c0506eb0372253d18
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Open source collaboration platform built for developers",
         "fr": "Plateforme de collaboration open source conçue pour les développeurs"
     },
-    "version": "7.3.0~ynh1",
+    "version": "7.2.0~ynh1",
     "url": "http://www.mattermost.org/",
     "upstream": {
         "license": "GPL-3.0-only",


### PR DESCRIPTION
Reverts YunoHost-Apps/mattermost_ynh#396 (Upgrade to Mattermost 7.3)

It breaks Boards on MariaDB (see [#367](https://github.com/YunoHost-Apps/mattermost_ynh/issues/367#issuecomment-1260083394)). This PR reverts the package to Mattermost 7.2.