### PR TITLE
Test upgrade from 7.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ It shall NOT be edited by hand.
 # Mattermost for YunoHost
 
 [![Integration level](https://dash.yunohost.org/integration/mattermost.svg)](https://dash.yunohost.org/appci/app/mattermost) ![Working status](https://ci-apps.yunohost.org/ci/badges/mattermost.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/mattermost.maintain.svg)
+
 [![Install Mattermost with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=mattermost)
 
 *[Lire ce readme en français.](./README_fr.md)*

--- a/README_fr.md
+++ b/README_fr.md
@@ -6,6 +6,7 @@ It shall NOT be edited by hand.
 # Mattermost pour YunoHost
 
 [![Niveau d’intégration](https://dash.yunohost.org/integration/mattermost.svg)](https://dash.yunohost.org/appci/app/mattermost) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/mattermost.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/mattermost.maintain.svg)
+
 [![Installer Mattermost avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=mattermost)
 
 *[Read this readme in english.](./README.md)*

--- a/check_process
+++ b/check_process
@@ -19,8 +19,8 @@
         setup_private=1
         setup_public=1
         upgrade=1
-        # 7.3.0
-        upgrade=1   from_commit=1677cb9fa9d95ab788a6acd5b310b09c7d2ab7df
+        # 7.2.0
+        upgrade=1   from_commit=738ba505f581ddd72889c889dcb34406250fea35
         backup_restore=1
         multi_instance=1
         port_already_use=0
@@ -44,11 +44,11 @@
         setup_private=1
         setup_public=1
         upgrade=1
-        upgrade=1   from_commit=1677cb9fa9d95ab788a6acd5b310b09c7d2ab7df
+        upgrade=1   from_commit=738ba505f581ddd72889c889dcb34406250fea35
 ;;; Options
 Email=kemenaran@gmail.com
 Notification=none
 ;;; Upgrade options
-    ; commit=00d02169435b8dc49744a1e896fe09001211d34c
-        name=Testing (#396)
+    ; commit=738ba505f581ddd72889c889dcb34406250fea35
+        name=7.2.0
         


### PR DESCRIPTION
## Problem

- *7.3.0 is broken according to https://github.com/YunoHost-Apps/mattermost_ynh/pull/377#issuecomment-1433738761*

## Solution

- *Test upgrade from 7.2.0 instead*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
