### PR TITLE
Fix PostreSQL migration in some cases

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -46,6 +46,8 @@ mariadb-to-pg() {
         ynh_psql_execute_as_root --sql='DROP INDEX public.idx_fileinfo_content_txt;' --database=$db_name
         ynh_psql_execute_as_root --sql='DROP INDEX public.idx_posts_message_txt;' --database=$db_name
         ynh_mysql_execute_as_root --sql="ALTER TABLE mattermost.Users DROP COLUMN IF EXISTS acceptedtermsofserviceid;" --database=$db_name
+        ynh_mysql_execute_as_root --sql="ALTER TABLE mattermost.SharedChannelRemotes DROP COLUMN IF EXISTS description;" --database=$db_name
+        ynh_mysql_execute_as_root --sql="ALTER TABLE mattermost.SharedChannelRemotes DROP COLUMN IF EXISTS nextsyncat;" --database=$db_name
 
         # Use pgloader to migrate database content from MariaDB to PostgreSQL
         tmpdir="$(mktemp -d)"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -35,7 +35,7 @@ mariadb-to-pg() {
         pushd $final_path
         ynh_systemd_action --service_name="$app" --action="stop"
         set +e
-		sudo -u mattermost timeout --preserve-status 120 "./bin/mattermost" 
+        sudo -u mattermost timeout --preserve-status 180 "./bin/mattermost"
         if [ "$?" != "0" ] && [ "$?" != "143" ] ; then
             ynh_die --message="Failed to run Mattermost to create PostgreSQL database tables" --ret_code=1
         fi


### PR DESCRIPTION
- [mariadb-to-pg: drop stray columns](https://github.com/YunoHost-Apps/mattermost_ynh/commit/350dd6703a94e77af0ec85a0adb6cd332bf5aa5b).
    These should have been removed in a previous migration, but weren't.

    _See https://github.com/mattermost/mattermost-server/issues/18351#issuecomment-1325648058_

- [mariadb-to-pg: increase mattermost timeout](https://github.com/YunoHost-Apps/mattermost_ynh/commit/41aba8856ee5ccc48b65d87874eb4b049a03d2fa)
    On a small VPS the 2 mn timeout is almost reached. Increase it to 3 mn.