### PR TITLE
Fix migration on some SQL systems

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -52,10 +52,9 @@ mariadb-to-pg() {
         # Focalboard is broken in Mattermost 7.3.0
         if ynh_compare_current_package_version --comparison eq --version 7.3.0~ynh1
         then
-            # Remove Focalboard tables
-            # Command from https://stackoverflow.com/a/1589324
-            cmd=$(ynh_mysql_execute_as_root --sql="SELECT CONCAT( 'DROP TABLE ', GROUP_CONCAT(table_name) , ';' ) AS statement FROM information_schema.tables WHERE table_schema = '$db_name' AND table_name LIKE 'focalboard_%';" --database=$db_name | tail -n 1)
-            ynh_mysql_execute_as_root --sql="$cmd" --database=$db_name
+            remove_focalboard_if_7_3_0="EXCLUDING TABLE NAMES MATCHING ~/^focalboard_/"
+        else
+            remove_focalboard_if_7_3_0=""
         fi
 
         # Use pgloader to migrate database content from MariaDB to PostgreSQL
@@ -73,6 +72,8 @@ WITH include no drop, truncate, create no tables,
 SET MySQL PARAMETERS
 net_read_timeout = '90',
 net_write_timeout = '180'
+
+$remove_focalboard_if_7_3_0
 
 ALTER SCHEMA '$db_name' RENAME TO 'public'
 


### PR DESCRIPTION
Fix this issue on Raspberry Pi:

```
ynh_mysql_execute_as_root '--sql=SELECT CONCAT( '\''DROP TABLE '\'', GROUP_CONCAT(table_name) , '\'';'\'' ) AS statement FROM information_schema.tables WHERE table_schema = '\''mattermost'\'' AND table_name LIKE '\''focalboard_%'\'';' --database=mattermost
WARNING - ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'NULL' at line 1
```