### PR TITLE
Migration: reduce the number of rows prefetched by pgloader

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -67,7 +67,7 @@ LOAD DATABASE
 
 WITH include no drop, truncate, create no tables,
      create no indexes, preserve index names, no foreign keys,
-     data only, workers = 16, concurrency = 1
+     data only, workers = 16, concurrency = 1, prefetch rows = 10000
 
 SET MySQL PARAMETERS
 net_read_timeout = '90',


### PR DESCRIPTION
This helps fixing stack overflow errors on large
databases.

See https://forum.yunohost.org/t/need-testers-for-the-latest-mattermost-upgrade/23992/29?u=kemenaran
