### PR TITLE
scripts: increase the PostgreSQL migration timeout again

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -35,7 +35,7 @@ mariadb-to-pg() {
         pushd $final_path
         ynh_systemd_action --service_name="$app" --action="stop"
         set +e
-        sudo -u mattermost timeout --preserve-status 180 "./bin/mattermost"
+        sudo -u mattermost timeout --preserve-status 300 "./bin/mattermost"
         if [ "$?" != "0" ] && [ "$?" != "143" ] ; then
             ynh_die --message="Failed to run Mattermost to create PostgreSQL database tables" --ret_code=1
         fi


### PR DESCRIPTION
It seems to be too short on [lesser-powered VMs](https://forum.yunohost.org/t/need-testers-for-the-latest-mattermost-upgrade/23992/32?u=kemenaran).

Increasing the timeout to 300 (the same duration than a regular launch of mattermost through mmctl, btw) [fixed the issue](https://forum.yunohost.org/t/need-testers-for-the-latest-mattermost-upgrade/23992/34?u=kemenaran).

