### PR TITLE
conf: upgrade to Mattermost ESR 8.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To explore the benefits of Mattermost’s enterprise features, you can replace t
 - New features and improvements released regularly
 
 
-**Shipped version:** 7.8.1~ynh2
+**Shipped version:** 8.1.1~ynh1
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -36,7 +36,7 @@ Pour explorer les avantages des fonctionnalités d'entreprise de Mattermost, vou
 - Nouvelles fonctionnalités et améliorations publiées régulièrement
 
 
-**Version incluse :** 7.8.1~ynh2
+**Version incluse :** 8.1.1~ynh1
 
 ## Captures d’écran
 

--- a/bump-mattermost.rb
+++ b/bump-mattermost.rb
@@ -135,7 +135,7 @@ if version.nil?
   abort("ERROR: The Mattermost release version must be provided.\nExample: ./bump-mattermost.sh 5.33.1")
 end
 
-VARIANTS = %i[team_amd64 enterprise_amd64 enterprise_arm64 team_arm64 team_armhf]
+VARIANTS = %i[team_amd64 enterprise_amd64 enterprise_arm64 team_arm64]
 
 # Compute releases URLs and sums
 releases = VARIANTS

--- a/conf/enterprise_amd64.src
+++ b/conf/enterprise_amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://releases.mattermost.com/7.8.1/mattermost-enterprise-7.8.1-linux-amd64.tar.gz
-SOURCE_SUM=2a6ce384092fd53a4e947b599cdfe27e4427cc3aa4d6b37e7e5e094ad6516d74
+SOURCE_URL=https://releases.mattermost.com/8.1.1/mattermost-enterprise-8.1.1-linux-amd64.tar.gz
+SOURCE_SUM=5ce9090089601c5c7746768c9799cda8069b6116468d0377d603cd9116810911
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/enterprise_arm64.src
+++ b/conf/enterprise_arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://releases.mattermost.com/7.8.1/mattermost-enterprise-7.8.1-linux-arm64.tar.gz
-SOURCE_SUM=a52fd6f2f9ae5b2c5ffa632239caccfe6f76342edf066ece08761c59597aca08
+SOURCE_URL=https://releases.mattermost.com/8.1.1/mattermost-enterprise-8.1.1-linux-arm64.tar.gz
+SOURCE_SUM=bca0bb54f257680fadbd3d568d870d6c1cd1352744dda419d71a07be82b7d2ca
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/team_amd64.src
+++ b/conf/team_amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://releases.mattermost.com/7.8.1/mattermost-team-7.8.1-linux-amd64.tar.gz
-SOURCE_SUM=79e0a0f1819ff59165b61cb1aeb4da0104b5cdbe7b32bd88c2a6b44cbd1c8039
+SOURCE_URL=https://releases.mattermost.com/8.1.1/mattermost-team-8.1.1-linux-amd64.tar.gz
+SOURCE_SUM=1ca6b77cc34be7bd2cea57f9dfa064e19c5556ab59c5e24e93dfdf6d0dc39603
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/team_arm64.src
+++ b/conf/team_arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://releases.mattermost.com/7.8.1/mattermost-team-7.8.1-linux-arm64.tar.gz
-SOURCE_SUM=60017d20593288e43228196ff57bf13d983482a0fea3b4b6273043cab30e8117
+SOURCE_URL=https://releases.mattermost.com/8.1.1/mattermost-team-8.1.1-linux-arm64.tar.gz
+SOURCE_SUM=0ca10276b140e814e352e7f5538de2de9545e11b4b2f3281159c5390f16c2f34
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Open source collaboration platform built for developers",
         "fr": "Plateforme de collaboration open source conçue pour les développeurs"
     },
-    "version": "7.8.1~ynh2",
+    "version": "8.1.1~ynh1",
     "url": "http://www.mattermost.org/",
     "upstream": {
         "license": "GPL-3.0-only",


### PR DESCRIPTION
## Problem

- The Mattermost version of this package is quite outdated.
- The manifest v2 branch upgrades the bundled Mattermost version, but:
  - The v2 branch has a lot of new code and still needs fixes
  - Older Yunohost instances won't be able to upgrade
 
## Solution

- Upgrade to an Extended Support Release version of Mattermost, before merging the v2 branch.

## Mattermost changelog

https://docs.mattermost.com/install/self-managed-changelog.html#release-v8-1-extended-support-release