### PR TITLE
Attempt to fix MySQL → PostgreSQL migration when using manifest v2

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -12,22 +12,19 @@ mariadb-to-pg() {
 
         ynh_print_info --message="Migrating to PostgreSQL database..."
 
+        # Retrieve MySQL user and password
         mysqlpwd=$(ynh_app_setting_get --app=$app --key=mysqlpwd)
 
-        # In old instance db_user is `mmuser`
         mysql_db_user="$db_user"
         if ynh_mysql_connect_as --user="mmuser" --password="$mysqlpwd" 2> /dev/null <<< ";"; then
+            # On old instances db_user is `mmuser`
             mysql_db_user="mmuser"
         fi
 
-        # Initialize PostgreSQL database
-        ynh_psql_test_if_first_run
-        ynh_psql_setup_db --db_user=$db_user --db_name=$db_name --db_pwd=$mysqlpwd
-        psqlpwd=$(ynh_app_setting_get --app=$app --key=psqlpwd)
-
-        # Configure the new database and run Mattermost in order to create tables
+        # The PostgreSQL database has already been created by Yunohost before running the script.
+        # Configure the new database and run Mattermost in order to create tables.
         ynh_write_var_in_file --file="$install_dir/config/config.json" --key="DriverName" --value="postgres" --after="SqlSettings"
-        ynh_write_var_in_file --file="$install_dir/config/config.json" --key="DataSource" --value="postgres://$db_user:$psqlpwd@localhost:5432/$db_name?sslmode=disable&connect_timeout=10" --after="SqlSettings"
+        ynh_write_var_in_file --file="$install_dir/config/config.json" --key="DataSource" --value="postgres://$db_user:$db_pwd@localhost:5432/$db_name?sslmode=disable&connect_timeout=10" --after="SqlSettings"
         cat "$install_dir/config/config.json"
         pushd $install_dir
         ynh_systemd_action --service_name="$app" --action="stop"
@@ -60,7 +57,7 @@ mariadb-to-pg() {
         cat <<EOT > $tmpdir/commands.load
 LOAD DATABASE
      FROM mysql://$mysql_db_user:$mysqlpwd@127.0.0.1:3306/$db_name
-     INTO postgresql://$db_user:$psqlpwd@127.0.0.1:5432/$db_name
+     INTO postgresql://$db_user:$db_pwd@127.0.0.1:5432/$db_name
 
 WITH include no drop, truncate, create no tables,
      create no indexes, preserve index names, no foreign keys,
@@ -82,16 +79,15 @@ EOT
         ynh_psql_execute_as_root --sql='CREATE INDEX idx_fileinfo_content_txt ON public.fileinfo USING gin (to_tsvector('\''english'\''::regconfig, content))' --database=$db_name
         ynh_psql_execute_as_root --sql='CREATE INDEX idx_posts_message_txt ON public.posts USING gin (to_tsvector('\''english'\''::regconfig, (message)::text));' --database=$db_name
 
-
         if ynh_compare_current_package_version --comparison eq --version 7.3.0~ynh1
         then
             # There is a problem with version 7.3.0 and the database migration.
             # More information here: https://forum.mattermost.com/t/migrating-from-mariadb-to-postgresql-db/14194/6
             ynh_psql_execute_as_root --sql="DELETE FROM db_migrations WHERE version=92;" --database=$db_name
         fi
+
         # Remove the MariaDB database
         ynh_mysql_remove_db --db_user=$mysql_db_user --db_name=$db_name
-
 }
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -45,8 +45,8 @@ fi
 # Check if using MariaDB
 # This migration should be done before the upgrade
 if mysqlshow | grep -q "^| $db_name "; then
-    # Mattermost only support MySQL and PostgreSQL (not MariaDB...)
-    # Migrate the database from MariaDB to PostgreSQL
+    # Mattermost recommands PostgreSQL over MySQL (and doesn't support MariaDB at all)
+    # Migrate the database from MySQL/MariaDB to PostgreSQL
     remove_psql_in_case_of_error=1
     mariadb-to-pg
 fi


### PR DESCRIPTION
The PostgreSQL database is already created by the manifest, no need to create it manually.

We want to use the proper password though.