### PR TITLE
Fix v2 database deletion on error

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -23,7 +23,7 @@ then
 	yunohost service remove $app
 fi
 
-# Remove the dedicated systemd config
+# Stop the server, and remove the dedicated systemd config
 ynh_remove_systemd_config
 
 # Remove the app-specific logrotate config
@@ -32,6 +32,7 @@ ynh_remove_logrotate
 # Remove the dedicated NGINX config
 ynh_remove_nginx_config
 
+# Remove the log file
 ynh_secure_remove --file="/var/log/$app"
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -35,6 +35,16 @@ ynh_remove_nginx_config
 # Remove the log file
 ynh_secure_remove --file="/var/log/$app"
 
+# If the user attempted to upgrade from an older MariaDB-based version, but the upgrade failed,
+# the 'remove' action will automatically remove the PostgreSQL database – but doesn't know
+# that a MariaDB database is still lying around.
+# In that case, remove the MariaDB database manually.
+if mysqlshow | grep -q "^| $db_name "
+then
+	ynh_script_progression --message="Removing MariaDB database..." --weight=1
+  ynh_mysql_remove_db --db_user=$db_user --db_name=$db_name
+fi
+
 #=================================================
 # END OF SCRIPT
 #=================================================


### PR DESCRIPTION
## Problem

When upgrading from a MariaDB version, if the upgrade fail, we want to remove both databases (the old MariaDB one and the PostreSQL one). Otherwise the backup restore will fail.

## Solution

Manually delete the MariaDB database if an older version is detected.

