### PR TITLE
Install automatically the Board and Agents plugins

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -609,7 +609,7 @@
   },
   "PluginSettings": {
     "Enable": true,
-    "EnableUploads": false,
+    "EnableUploads": true,
     "AllowInsecureDownloadURL": false,
     "EnableHealthCheck": true,
     "Directory": "./plugins",

--- a/manifest.toml
+++ b/manifest.toml
@@ -119,9 +119,9 @@ ram.runtime = "50M"
     boards.url = "/boards"
     boards.show_tile = true
     boards.allowed = "visitors"
-    boards.url = "/playbooks"
-    boards.show_tile = true
-    boards.allowed = "visitors"
+    playbooks.url = "/playbooks"
+    playbooks.show_tile = true
+    playbooks.allowed = "visitors"
 
     [resources.apt]
     packages = "postgresql, pgloader"

--- a/manifest.toml
+++ b/manifest.toml
@@ -72,6 +72,18 @@ ram.runtime = "50M"
     example = "Team"
     default = "Team"
 
+    [install.focalboards]
+    ask.en = "Install FocalBoards"
+    ask.fr = "Installer FocalBoards"
+    type = "boolean"
+    default = false
+
+    [install.agents]
+    ask.en = "Install AI Agents"
+    ask.fr = "Installer les Agents AI"
+    type = "boolean"
+    default = false
+
 [resources]
     [resources.sources]
 
@@ -101,6 +113,12 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
+    admin.url = "/admin_console"
+    admin.show_tile = true
+    admin.allowed = "admins"
+    boards.url = "/boards"
+    boards.show_tile = true
+    boards.allowed = "visitors"
 
     [resources.apt]
     packages = "postgresql, pgloader"

--- a/manifest.toml
+++ b/manifest.toml
@@ -119,6 +119,9 @@ ram.runtime = "50M"
     boards.url = "/boards"
     boards.show_tile = true
     boards.allowed = "visitors"
+    boards.url = "/playbooks"
+    boards.show_tile = true
+    boards.allowed = "visitors"
 
     [resources.apt]
     packages = "postgresql, pgloader"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -110,7 +110,3 @@ install_agents() {
     $command plugin add ../sources/mattermost-plugin-agents-v1.4.0.tar.gz
     $command plugin enable focalboards
 }
-
-install_matterbridge() {
-
-}

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -100,13 +100,17 @@ EOT
 install_focalboards() {
     command=$install_dir/bin/mmctl
     
-    $command plugin add ../sources/mattermost-plugin-boards-v9.1.6.tar.gz
-    $command plugin enable focalboards
+    if [[ -f $command ]];then
+        $command plugin add ../sources/mattermost-plugin-boards-v9.1.6.tar.gz
+        $command plugin enable focalboards
+    fi
 }
 
 install_agents() {
     command=$install_dir/bin/mmctl
     
-    $command plugin add ../sources/mattermost-plugin-agents-v1.4.0.tar.gz
-    $command plugin enable focalboards
+    if [[ -f $command ]];then
+        $command plugin add ../sources/mattermost-plugin-agents-v1.4.0.tar.gz
+        $command plugin enable focalboards
+    fi
 }

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -96,3 +96,21 @@ EOT
         # Remove the MariaDB database
         ynh_mysql_drop_db $db_name && ynh_mysql_drop_user $db_user
 }
+
+install_focalboards() {
+    command=$install_dir/bin/mmctl
+    
+    $command plugin add ../sources/mattermost-plugin-boards-v9.1.6.tar.gz
+    $command plugin enable focalboards
+}
+
+install_agents() {
+    command=$install_dir/bin/mmctl
+    
+    $command plugin add ../sources/mattermost-plugin-agents-v1.4.0.tar.gz
+    $command plugin enable focalboards
+}
+
+install_matterbridge() {
+
+}

--- a/scripts/install
+++ b/scripts/install
@@ -71,6 +71,15 @@ ynh_replace --match='"EnableLocalMode": true' --replace='"EnableLocalMode": fals
 ynh_systemctl --service=$app --action=restart --log_path=systemd
 
 #=================================================
+# CREATE ADMIN AND FIRST TEAM
+#=================================================
+ynh_script_progression "Installing focalBoards..."
+
+if [ $focalboards -eq 1 ];then
+  install_focalboards
+fi
+
+#=================================================
 # END OF SCRIPT
 #=================================================
 


### PR DESCRIPTION
## Problem

- *I modified this app to install automatically the Board and Agents plugins, and create according tiles in the yunohost app boards*

## Solution

- *I modified the permissions boards to add Boards and Playbooks and a separate for the admin console.*
- *I added a script that install Board and Agent plugins by cliking in the install panel*
- *I change thapp config to upload plugins by defaults*

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
